### PR TITLE
Quicclinks card component

### DIFF
--- a/src/components/QuicklinksCard.js
+++ b/src/components/QuicklinksCard.js
@@ -1,8 +1,19 @@
 import React from 'react';
+import { A, UL, LI, H2 } from './Typography';
+import { Card } from '../components/Common.js'
 
 // TODO: Create quicklinks card component
-export default ({ title }) => {
+export default ({ title, links }) => {
   return (
-    <p>{title}</p>
+    <Card>
+      <H2>{title}</H2>
+      <UL>
+        {
+          links.map((link) =>
+            <LI><A href={link.href}>{link.label}</A></LI>
+          )
+        }
+      </UL>
+    </Card>
   );
 }

--- a/src/components/Typography.js
+++ b/src/components/Typography.js
@@ -30,16 +30,19 @@ export const P = styled.p`
   ${p => (p.highlight && `color: ${p.theme.colors.link}`)};
   margin: 0;
 `
-
+// note: didn't use text-decoration: underline here because the defaut underline doesn't match designs' thiccness - Allison
 export const A = styled.a`
   cursor: pointer;
   text-decoration: none;
+  border-bottom: 1px solid ${p => p.theme.colors.text};
   color: ${p => p.theme.colors.link};
   transition: all 0.5s cubic-bezier(.25,.8,.25,1);
   &:hover {
     color: ${p => p.theme.colors.linkHover};
+    border-bottom: 1px solid ${p => p.theme.colors.linkHover};
   }
   &:focus {
     color: ${p => p.theme.colors.linkHover};
+    border-bottom: 1px solid ${p => p.theme.colors.linkHover};
   }
 `

--- a/src/components/Typography.js
+++ b/src/components/Typography.js
@@ -46,3 +46,15 @@ export const A = styled.a`
     border-bottom: 1px solid ${p => p.theme.colors.linkHover};
   }
 `
+export const UL = styled.ul`
+  list-style: none;
+  padding-inline-start: 10px;
+`
+export const LI = styled.li`
+  margin: 0 0 10px 0; 
+  &:before {
+    content: "-";
+    padding-right: 8px;
+    color: ${p => p.theme.colors.text};
+  }
+`

--- a/src/components/Typography.js
+++ b/src/components/Typography.js
@@ -34,7 +34,7 @@ export const P = styled.p`
 export const A = styled.a`
   cursor: pointer;
   text-decoration: none;
-  border-bottom: 1px solid ${p => p.theme.colors.text};
+  border-bottom: 1px solid ${p => p.theme.colors.link};
   color: ${p => p.theme.colors.link};
   transition: all 0.5s cubic-bezier(.25,.8,.25,1);
   &:hover {

--- a/src/containers/Quicklinks.js
+++ b/src/containers/Quicklinks.js
@@ -76,7 +76,6 @@ export const QuickLinks = () => {
       })
   }, [setLinks])
 
-  //TODO: Use QuickLinks card component
   return (
     <ButtonContainer>
       {

--- a/src/containers/Quicklinks.js
+++ b/src/containers/Quicklinks.js
@@ -81,7 +81,8 @@ export const QuickLinks = () => {
     <ButtonContainer>
       {
         links.map(link => (
-          <QuicklinksCard key={link.label} title={link.label} />
+          // TODO: map on link categories, not links
+          <QuicklinksCard key={link.label} title={link.label} links={links} />
         ))
       }
     </ButtonContainer>

--- a/src/theme/ThemeProvider.js
+++ b/src/theme/ThemeProvider.js
@@ -8,8 +8,8 @@ const theme = {
     primary: '#31E0E0',
     highlight: 'rgba(255, 255, 255, 0.6)',
     text: '#fff',
-    link: '#31E0E0',
-    linkHover: '#fff' //TODO
+    link: '#fff',
+    linkHover: '#31E0E0' //TODO
   },
   typography: {
     h1: {


### PR DESCRIPTION
Note the card component width is smol (fits to content) for now, I was thinking the Quicklinks page is probably pretty similar to the FAQ sections where the Accordions array is split in half and placed in two columns. If this is the right assumption, that means we can leave component width to later when #37 is started? Pls correct me if I'm wrong please! 

BTW looks like the link categories and links array in quicklinks.js is a WIP :) 

![image](https://user-images.githubusercontent.com/47487758/95395242-01f60280-08b3-11eb-879f-e18a9c5d8e3d.png)
