### PR TITLE
Mobile sidebar basic functionality and add mediaQueries breakpoints

### DIFF
--- a/src/assets/menu.svg
+++ b/src/assets/menu.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3.8501 20.7H24.5501V18.4H3.8501V20.7ZM3.8501 14.95H24.5501V12.65H3.8501V14.95ZM3.85014 6.90002V9.20002H24.5501V6.90002H3.85014Z" fill="white"/>
+</svg>

--- a/src/components/Common.js
+++ b/src/components/Common.js
@@ -10,7 +10,7 @@ const screenBreakpoints = {
 }
 
 export const maxWidthMediaQueries = ((size) => {
-  return `@media only screen and (max-width: ${screenBreakpoints[size]}px)`;
+  return `@media only screen and (max-width: ${screenBreakpoints[size]}px)`
 })
 
 export const CardLike = css`
@@ -62,7 +62,7 @@ export const DetailContainer = styled.div`
   flex-wrap: wrap;
   width: 100%;
 
-  ${maxWidthMediaQueries("desktop")} {
+  ${maxWidthMediaQueries('desktop')} {
     display: block;
   }
 `

--- a/src/components/Common.js
+++ b/src/components/Common.js
@@ -2,6 +2,12 @@ import styled, { css } from 'styled-components'
 import { text } from './Typography'
 import { P } from './Typography';
 
+const screenBreakpoints = [576, 768, 992, 1200]
+
+export const mediaQueries = screenBreakpoints.map(
+  bp => `@media only screen and (max-width: ${bp}px)`
+)
+
 export const CardLike = css`
   padding: 2em;
   border-radius: 3px;
@@ -51,7 +57,7 @@ export const DetailContainer = styled.div`
   flex-wrap: wrap;
   width: 100%;
 
-  @media (max-width: 1200px) {
+  ${[mediaQueries[3]]} {
     display: block;
   }
 `
@@ -76,9 +82,3 @@ export const DetailColumn = styled.ul`
 export const DetailAnswer = styled(P)`
   margin-bottom: 0.85em;
 `
-
-const breakpoints = [576, 768, 992, 1200]
-
-export const mediaQueries = breakpoints.map(
-  bp => `@media only screen and (max-width: ${bp}px)`
-)

--- a/src/components/Common.js
+++ b/src/components/Common.js
@@ -2,11 +2,16 @@ import styled, { css } from 'styled-components'
 import { text } from './Typography'
 import { P } from './Typography';
 
-const screenBreakpoints = [576, 768, 992, 1200]
+const screenBreakpoints = {
+  xs: 576,
+  mobile: 768,
+  tablet: 992,
+  desktop: 1200,
+}
 
-export const mediaQueries = screenBreakpoints.map(
-  bp => `@media only screen and (max-width: ${bp}px)`
-)
+export const maxWidthMediaQueries = ((size) => {
+  return `@media only screen and (max-width: ${screenBreakpoints[size]}px)`;
+})
 
 export const CardLike = css`
   padding: 2em;
@@ -57,7 +62,7 @@ export const DetailContainer = styled.div`
   flex-wrap: wrap;
   width: 100%;
 
-  ${[mediaQueries[3]]} {
+  ${maxWidthMediaQueries("desktop")} {
     display: block;
   }
 `

--- a/src/components/Common.js
+++ b/src/components/Common.js
@@ -76,3 +76,9 @@ export const DetailColumn = styled.ul`
 export const DetailAnswer = styled(P)`
   margin-bottom: 0.85em;
 `
+
+const breakpoints = [576, 768, 992, 1200]
+
+export const mediaQueries = breakpoints.map(
+  bp => `@media only screen and (max-width: ${bp}px)`
+)

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -28,10 +28,10 @@ const Menu = styled.img`
   width: 30px;
 `;
 
-export default ({ openSidebar }) => {
+export default ({ showSidebar, setShowSidebar }) => {
   return (
     <MobileMenuBarContainer>
-      <Menu src={menu} alt="menu" onClick={openSidebar} />
+      <Menu src={menu} alt="menu" onClick={() => setShowSidebar(!showSidebar)} />
       <a href="/">
         <Logo src={logo} alt="logo" />
       </a>

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -2,12 +2,12 @@ import React from 'react';
 import styled from 'styled-components'
 import logo from '../assets/logo.svg'
 import menu from '../assets/menu.svg'
-
+import { mediaQueries } from './Common';
 
 const MobileMenuBarContainer = styled.div`
   display: none; 
   padding: 20px;
-  @media only screen and (max-width: 600px) {
+  ${[mediaQueries[0]]} {
     display: inline-block;
     text-align: center;
     width: 100%;

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -6,12 +6,12 @@ import { maxWidthMediaQueries } from './Common';
 
 const MobileMenuBarContainer = styled.div`
   display: none; 
-  padding: 15px;
-  ${maxWidthMediaQueries("mobile")} {
+  ${maxWidthMediaQueries('mobile')} {
+    padding: 15px;
     display: inline-block;
     text-align: center;
     width: 100%;
-    box-sizing: border-box
+    box-sizing: border-box;
     -webkit-box-shadow: 0 6px 8px -8px #000;
     -moz-box-shadow: 0 6px 8px -8px #000;
     box-shadow: 0 6px 8px -8px #000;

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -2,12 +2,12 @@ import React from 'react';
 import styled from 'styled-components'
 import logo from '../assets/logo.svg'
 import menu from '../assets/menu.svg'
-import { mediaQueries } from './Common';
+import { maxWidthMediaQueries } from './Common';
 
 const MobileMenuBarContainer = styled.div`
   display: none; 
   padding: 20px;
-  ${[mediaQueries[0]]} {
+  ${maxWidthMediaQueries("mobile")} {
     display: inline-block;
     text-align: center;
     width: 100%;

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from 'styled-components'
+import logo from '../assets/logo.svg'
+import menu from '../assets/menu.svg'
+
+
+const MobileMenuBarContainer = styled.div`
+  display: none; 
+  padding: 20px;
+  @media only screen and (max-width: 600px) {
+    display: inline-block;
+    text-align: center;
+    width: 100%;
+    -webkit-box-shadow: 0 6px 8px -8px #000;
+    -moz-box-shadow: 0 6px 8px -8px #000;
+    box-shadow: 0 6px 8px -8px #000;
+  }
+`;
+
+const Logo = styled.img`
+  display: inline-block;
+  margin-left: -30px;
+  width: 20px;
+`;
+
+const Menu = styled.img`
+  float: left;
+  width: 30px;
+`;
+
+export default ({ openSidebar }) => {
+  return (
+    <MobileMenuBarContainer>
+      <Menu src={menu} alt="menu" onClick={openSidebar} />
+      <a href="/">
+        <Logo src={logo} alt="logo" />
+      </a>
+    </MobileMenuBarContainer>
+  );
+}

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -6,11 +6,12 @@ import { maxWidthMediaQueries } from './Common';
 
 const MobileMenuBarContainer = styled.div`
   display: none; 
-  padding: 20px;
+  padding: 15px;
   ${maxWidthMediaQueries("mobile")} {
     display: inline-block;
     text-align: center;
     width: 100%;
+    box-sizing: border-box
     -webkit-box-shadow: 0 6px 8px -8px #000;
     -moz-box-shadow: 0 6px 8px -8px #000;
     box-shadow: 0 6px 8px -8px #000;
@@ -19,7 +20,7 @@ const MobileMenuBarContainer = styled.div`
 
 const Logo = styled.img`
   display: inline-block;
-  margin-left: -30px;
+  margin-left: -50px;
   width: 20px;
 `;
 

--- a/src/components/MobileMenuBar.js
+++ b/src/components/MobileMenuBar.js
@@ -28,10 +28,10 @@ const Menu = styled.img`
   width: 30px;
 `;
 
-export default ({ showSidebar, setShowSidebar }) => {
+export default ({ showMobileSidebar, setShowMobileSidebar }) => {
   return (
     <MobileMenuBarContainer>
-      <Menu src={menu} alt="menu" onClick={() => setShowSidebar(!showSidebar)} />
+      <Menu src={menu} alt="menu" onClick={() => setShowMobileSidebar(!showMobileSidebar)} />
       <a href="/">
         <Logo src={logo} alt="logo" />
       </a>

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import Sidebar from './Sidebar';
 import MobileMenuBar from './MobileMenuBar';
@@ -20,26 +20,32 @@ const Content = styled.div`
   width: 100%;
 `;
 
-const SidebarContainer = styled.div`
-  min-height: 100%;
-  border-right: 1px solid rgba(255, 255, 255, 0.3);
-  @media (max-width: 600px) {
-    display: none;
-  }
-`;
 
-const openSidebar = () => {
-  window.alert("hi")
+
+const Page = ({ children }) => {
+  const SidebarContainer = styled.div`
+    min-height: 100%;
+    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    transition: opacity 1s ease-out;
+    @media (max-width: 600px) {
+      ${props => props.display ? 'visibility: visible' : 'visibility: hidden; display: none'};
+      
+    }
+  `;
+
+
+  const [showSidebar, setShowSidebar] = useState(false);
+  return (
+    <Container>
+      <SidebarContainer display={showSidebar}>
+        <Sidebar />
+      </SidebarContainer>
+      <LeftColumn>
+        <MobileMenuBar showSidebar={showSidebar} setShowSidebar={setShowSidebar} />
+        <Content>{children}</Content>
+      </LeftColumn>
+    </Container>
+  );
 }
 
-export default ({ children }) => (
-  <Container>
-    <SidebarContainer>
-      <Sidebar />
-    </SidebarContainer>
-    <LeftColumn>
-      <MobileMenuBar openSidebar={openSidebar} />
-      <Content>{children}</Content>
-    </LeftColumn>
-  </Container>
-);
+export default Page; 

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -28,20 +28,20 @@ const Page = ({ children }) => {
     border-right: 1px solid rgba(255, 255, 255, 0.3);
     transition: opacity 1s ease-out;
     @media (max-width: 600px) {
-      ${props => props.display ? 'visibility: visible' : 'visibility: hidden; display: none'};
+      ${props => props.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none'};
       
     }
   `;
 
 
-  const [showSidebar, setShowSidebar] = useState(false);
+  const [showMobileSidebar, setShowMobileSidebar] = useState(false);
   return (
     <Container>
-      <SidebarContainer display={showSidebar}>
+      <SidebarContainer showMobileSidebar={showMobileSidebar}>
         <Sidebar />
       </SidebarContainer>
       <LeftColumn>
-        <MobileMenuBar showSidebar={showSidebar} setShowSidebar={setShowSidebar} />
+        <MobileMenuBar showMobileSidebar={showMobileSidebar} setShowMobileSidebar={setShowMobileSidebar} />
         <Content>{children}</Content>
       </LeftColumn>
     </Container>

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
 import Sidebar from './Sidebar';
+import MobileMenuBar from './MobileMenuBar';
 
 const Container = styled.div`
   display: flex;
   align-items: stretch;
   min-height: 100vh;
+`;
+
+const LeftColumn = styled.div`
+  box-sizing: border-box;
+  width: 100%;
 `;
 
 const Content = styled.div`
@@ -14,9 +20,26 @@ const Content = styled.div`
   width: 100%;
 `;
 
+const SidebarContainer = styled.div`
+  min-height: 100%;
+  border-right: 1px solid rgba(255, 255, 255, 0.3);
+  @media (max-width: 600px) {
+    display: none;
+  }
+`;
+
+const openSidebar = () => {
+  window.alert("hi")
+}
+
 export default ({ children }) => (
   <Container>
-    <Sidebar />
-    <Content>{children}</Content>
+    <SidebarContainer>
+      <Sidebar />
+    </SidebarContainer>
+    <LeftColumn>
+      <MobileMenuBar openSidebar={openSidebar} />
+      <Content>{children}</Content>
+    </LeftColumn>
   </Container>
 );

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Sidebar from './Sidebar';
 import MobileMenuBar from './MobileMenuBar';
+import { mediaQueries } from './Common';
 
 const Container = styled.div`
   display: flex;
@@ -27,7 +28,7 @@ const Page = ({ children }) => {
     min-height: 100%;
     border-right: 1px solid rgba(255, 255, 255, 0.3);
     transition: opacity 1s ease-out;
-    @media (max-width: 600px) {
+    ${[mediaQueries[0]]} {
       ${props => props.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none'};
       
     }

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -9,7 +9,7 @@ const Container = styled.div`
   min-height: 100vh;
 `;
 
-const LeftColumn = styled.div`
+const RightContentContainer = styled.div`
   box-sizing: border-box;
   width: 100%;
 `;
@@ -29,10 +29,10 @@ const Page = ({ children }) => {
   return (
     <Container>
       <Sidebar showMobileSidebar={showMobileSidebar} />
-      <LeftColumn>
+      <RightContentContainer>
         <MobileMenuBar showMobileSidebar={showMobileSidebar} setShowMobileSidebar={setShowMobileSidebar} />
         <Content>{children}</Content>
-      </LeftColumn>
+      </RightContentContainer>
     </Container>
   );
 }

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import Sidebar from './Sidebar';
 import MobileMenuBar from './MobileMenuBar';
-import { mediaQueries } from './Common';
 
 const Container = styled.div`
   display: flex;
@@ -24,23 +23,12 @@ const Content = styled.div`
 
 
 const Page = ({ children }) => {
-  const SidebarContainer = styled.div`
-    min-height: 100%;
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
-    transition: opacity 1s ease-out;
-    ${[mediaQueries[0]]} {
-      ${props => props.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none'};
-      
-    }
-  `;
 
 
   const [showMobileSidebar, setShowMobileSidebar] = useState(false);
   return (
     <Container>
-      <SidebarContainer showMobileSidebar={showMobileSidebar}>
-        <Sidebar />
-      </SidebarContainer>
+      <Sidebar showMobileSidebar={showMobileSidebar} />
       <LeftColumn>
         <MobileMenuBar showMobileSidebar={showMobileSidebar} setShowMobileSidebar={setShowMobileSidebar} />
         <Content>{children}</Content>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -10,7 +10,7 @@ const SidebarContainer = styled.div`
   min-height: 100%;
   border-right: 1px solid rgba(255, 255, 255, 0.3);
   transition: opacity 1s ease-out;
-  ${maxWidthMediaQueries("mobile")} {
+  ${maxWidthMediaQueries('mobile')} {
     ${props => props.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none'};
     
   }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,14 +3,14 @@ import styled from 'styled-components'
 import { Link, useLocation } from 'wouter'
 import { A } from './Typography'
 import logo from '../assets/logo.svg'
-import { mediaQueries } from './Common';
+import { maxWidthMediaQueries } from './Common';
 
 const SidebarContainer = styled.div`
   min-width: 275px;
   min-height: 100%;
   border-right: 1px solid rgba(255, 255, 255, 0.3);
   transition: opacity 1s ease-out;
-  ${[mediaQueries[0]]} {
+  ${maxWidthMediaQueries("mobile")} {
     ${props => props.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none'};
     
   }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,9 +3,17 @@ import styled from 'styled-components'
 import { Link, useLocation } from 'wouter'
 import { A } from './Typography'
 import logo from '../assets/logo.svg'
+import { mediaQueries } from './Common';
 
 const SidebarContainer = styled.div`
   min-width: 275px;
+  min-height: 100%;
+  border-right: 1px solid rgba(255, 255, 255, 0.3);
+  transition: opacity 1s ease-out;
+  ${[mediaQueries[0]]} {
+    ${props => props.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none'};
+    
+  }
 `;
 
 const Logo = styled.img`
@@ -56,7 +64,7 @@ const LiveLabel = styled.p`
   padding: 5px;
 `
 
-export default () => {
+export default ({ showMobileSidebar }) => {
   const [location] = useLocation();
 
   const links = [
@@ -72,7 +80,7 @@ export default () => {
   }
 
   return (
-    <SidebarContainer>
+    <SidebarContainer showMobileSidebar={showMobileSidebar}>
       <Logo src={logo} alt="logo" />
       <LiveLabel>
         <LiveDot />LIVE

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -5,7 +5,6 @@ import { A } from './Typography'
 import logo from '../assets/logo.svg'
 
 const SidebarContainer = styled.div`
-  border-right: 1px solid rgba(255, 255, 255, 0.3);
   min-width: 275px;
 `;
 


### PR DESCRIPTION
Sidebar hides and hamburger menu shows when screen is at 600px: 
![Screen Shot 2020-11-03 at 1 27 23 AM](https://user-images.githubusercontent.com/47487758/97969736-5470f480-1d75-11eb-8335-9f6b02bc1b3e.png)
![Screen Shot 2020-11-03 at 1 27 29 AM](https://user-images.githubusercontent.com/47487758/97969738-55098b00-1d75-11eb-9aed-9dc5e69143f4.png)
When hamburger menu is clicked, sidebar menu appears: 
![Screen Shot 2020-11-03 at 1 27 33 AM](https://user-images.githubusercontent.com/47487758/97969739-55098b00-1d75-11eb-89ed-0ea0147d2d0a.png)
Sidebar menu disappears again when hamburger menu clicked for the second time. 

Logo links to home page (href="/"). 
Cross-browser: 
✔️  Chrome (developed)
✔️  Chrome dev tools for iPhone X Max
✔️  Safari
✔️  Firefox 
