### PR TITLE
add HackerApplicationContext to handle storing the hacker application + autosave

### DIFF
--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { useAuth } from './Auth'
+import { getUserApplication, updateUserApplication } from './firebase'
+import firebase from 'firebase/app'
+
+const HackerApplicationContext = createContext()
+
+export function useHackerApplication() {
+  return useContext(HackerApplicationContext)
+}
+
+export function HackerApplicationProvider({ children }) {
+  const { user } = useAuth()
+  const [application, setApplication] = useState({})
+  const [updated, setUpdated] = useState(false)
+
+  /**Initialize retrieval of hacker application */
+  useEffect(() => {
+    const retrieveApplication = async () => {
+      const app = await getUserApplication(user.uuid)
+      setApplication(app)
+      setUpdated(false)
+    }
+    retrieveApplication()
+  }, [user.uuid])
+
+  /**Saves the users application, can be called manually or through interval */
+  const forceSave = useCallback(async () => {
+    const updatedApp = {
+      ...application,
+      submission: {
+        lastUpdated: firebase.firestore.Timestamp.now(),
+        submitted: false,
+      },
+    }
+    await updateUserApplication(user.uuid, updatedApp)
+    setApplication(updatedApp)
+    setUpdated(false)
+  }, [application, user.uuid])
+
+  /**Checks whether the app has been updated and force saves it if it has */
+  const syncAppToFirebase = useCallback(async () => {
+    if (updated) {
+      return forceSave()
+    }
+  }, [updated, forceSave])
+
+  /**Setup auto-saving every 30 seconds */
+  useEffect(() => {
+    let interval = setInterval(syncAppToFirebase, 30000)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [syncAppToFirebase, user.uuid])
+
+  /**Update the updated variable when making changes to the new app */
+  const updateApplication = newApp => {
+    setApplication(newApp)
+    setUpdated(true)
+  }
+
+  return (
+    <HackerApplicationContext.Provider value={{ application, updateApplication, forceSave }}>
+      {children}
+    </HackerApplicationContext.Provider>
+  )
+}

--- a/src/utility/firebase.js
+++ b/src/utility/firebase.js
@@ -92,3 +92,11 @@ export const getProject = async (user_id, setProjectCallback, setFeedbackCallbac
       })
   }
 }
+
+export const getUserApplication = async uuid => {
+  return (await applicantsRef.doc(uuid).get()).data()
+}
+
+export const updateUserApplication = async (uuid, newApp) => {
+  return applicantsRef.doc(uuid).set(newApp)
+}


### PR DESCRIPTION
### what is the hacker application context?
- This is a React Context which allows us to easily access the hacker application from any part of the site where auth is enforced.
- It lets you easily update, save and access the logged in hackers' application. 

### Using the context
Currently I haven't setup the context because i'm waiting for my auth PR to be merged in first. I'll set it up in the routing later. Essentially, anywhere that needs access to the hackerapp must be inside `<AuthProvider>` and `<HackerApplicationProvider>`

To access the hacker app or update it, you should use this hook:
```javascript
const { application, updateApplication, forceSave } = useHackerApplication()
```
- application: the actual application that should be rendered in the app. Holds all the current data for the application.
- updateApplication: should be used like the set function of a useState hook    (e.g.)

   ```javascript
	updateApplication({...application, ...newValues})
	```
- forceSave: This forces the application context to save the current application onto firebase. If this isn't called, the application will be synced every 30 seconds (if changes have been detected)

### Technical details of the context

- The context uses two state variables, one to hold the application and another to hold whether the application has been updated or not.
- When updateApplication is called, it updates the state variable for the application and sets updated to true. 
Every 30 seconds, an interval will check whether the application has been updated. If it has, it will save it to firebase.

**Important note, when the application page first loads, the application might be null. This is because it is still retrieving the application data from firebase. This needs to be handled in the frontend appropriately (loading or otherwise)**