### PR TITLE
Auth for judging admin page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,6 +72,15 @@ const NoAuthRoute = ({ path, children }) => {
   )
 }
 
+const AdminAuthPageRoute = ({ path, children }) => {
+  const { isAuthed, user } = useAuth()
+  return (
+    <Route path={path}>
+      {isAuthed && user.admin ? <Page>{children}</Page> : <Redirect to="/login" />}
+    </Route>
+  )
+}
+
 function App() {
   useEffect(() => {
     const unsubscribe = db
@@ -136,9 +145,9 @@ function App() {
               <AuthPageRoute path="/judging">
                 <Judging />
               </AuthPageRoute>
-              <PageRoute path="/judging/admin">
+              <AdminAuthPageRoute path="/judging/admin">
                 <JudgingAdmin />
-              </PageRoute>
+              </AdminAuthPageRoute>
               <AuthPageRoute path="/judging/view/:id">
                 {params => <JudgingView id={params.id} />}
               </AuthPageRoute>

--- a/src/utility/Auth.js
+++ b/src/utility/Auth.js
@@ -10,6 +10,11 @@ export function useAuth() {
   return useContext(AuthContext)
 }
 
+export const checkAdminClaim = async user => {
+  const token = await user.getIdTokenResult()
+  return Object.prototype.hasOwnProperty.call(token.claims, 'admin')
+}
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -22,6 +27,8 @@ export function AuthProvider({ children }) {
       }
       const status = await getUserStatus(currUser)
       currUser.status = status
+      const admin = await checkAdminClaim(currUser)
+      currUser.admin = admin
       setUser(currUser)
       setLoading(false)
     })
@@ -40,6 +47,8 @@ const handleUser = async (setUser, setLocation) => {
   const user = firebase.auth().currentUser
   const status = await getUserStatus(user)
   user.status = status
+  const admin = await checkAdminClaim(user)
+  user.admin = admin
   setUser(user)
   setLocation(getRedirectUrl(status))
 }


### PR DESCRIPTION
### User object changes
- user object now has an admin field that will be true if they are an nwPlus admin or false if they are not.

	```javascript
	user.admin //true if they are an admin
	```
### New auth route
- `<AdminAuthPageRoute />` is a new route that is only accessible by nw admins. 

- Judging admin is now covered by this route.

### Testing
#### Test 1:
- be not logged in
- try to navigate to /judging/admin
- you should be redirected to /login
#### Test 2:
- be logged in to a NOT nwPlus email
- try to navigate to /judging/admin
- you should be redirected to /application
#### Test 3:
- Be logged into your nwPlus admin email
- try to navigate to /judging/admin
- You should see the admin panel