### PR TITLE
TEMPORARILY fix IOS mobile Notifications crash bug 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ import {
 } from './pages'
 import Page from './components/Page'
 import { db } from './utility/firebase'
-import { DB_COLLECTION, DB_HACKATHON } from './utility/Constants'
+import { DB_COLLECTION, DB_HACKATHON, IS_DEVICE_IOS } from './utility/Constants'
 import notifications from './utility/notifications'
 import { AuthProvider, getRedirectUrl, useAuth } from './utility/Auth'
 import { HackerApplicationProvider } from './utility/HackerApplicationContext'
@@ -110,22 +110,27 @@ const JudgingViewContainer = ({ params }) => {
 }
 
 function App() {
+  // TODO create reusable Announcements firebase ref in firebase.js to avoid redundant fb calls in Announcements.js
   useEffect(() => {
-    const unsubscribe = db
-      .collection(DB_COLLECTION)
-      .doc(DB_HACKATHON)
-      .collection('Announcements')
-      .orderBy('timestamp', 'desc')
-      .onSnapshot(querySnapshot => {
-        // firebase doc that triggered db change event
-        const changedDoc = querySnapshot.docChanges()[0]
+    // don't notify users on IOS devices because Notification API incompatible
+    if (!IS_DEVICE_IOS) {
+      const unsubscribe = db
+        .collection(DB_COLLECTION)
+        .doc(DB_HACKATHON)
+        .collection('Announcements')
+        .orderBy('timestamp', 'desc')
+        .onSnapshot(querySnapshot => {
+          // firebase doc that triggered db change event
+          const changedDoc = querySnapshot.docChanges()[0]
 
-        // don't want to notify on 'remove' + 'modified' db events
-        if (changedDoc && changedDoc.type === 'added') {
-          notifyUser(changedDoc.doc.data())
-        }
-      })
-    return unsubscribe
+          // don't want to notify on 'remove' + 'modified' db events
+          if (changedDoc && changedDoc.type === 'added') {
+            notifyUser(changedDoc.doc.data())
+          }
+        })
+
+      return unsubscribe
+    }
   }, [])
 
   return (

--- a/src/components/Announcements.js
+++ b/src/components/Announcements.js
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown'
 import { Card } from './Common'
 import { H1, P, A } from './Typography'
 import NotificationToggle from '../containers/NotificationToggle'
+import { IS_DEVICE_IOS } from '../utility/Constants'
 
 const StyledH1 = styled(H1)`
   margin: 0 0 0 0;
@@ -34,11 +35,12 @@ const AnnouncementHeader = styled.div`
   }
 `
 
+// hide notification toggle on IOS devices because Notification API incompatible
 export default ({ announcements }) => (
   <Card>
     <AnnouncementHeader>
       <StyledH1>Announcements</StyledH1>
-      <NotificationToggle />
+      {!IS_DEVICE_IOS ? <NotificationToggle /> : null}
     </AnnouncementHeader>
     {announcements.map(announcement => {
       const timeAgo = format(announcement.timestamp)

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -5,6 +5,7 @@ export const DB_HACKATHON = 'LHD2021'
 
 export const FAQ_COLLECTION = 'FAQ'
 export const NOTIFICATION_SETTINGS_CACHE_KEY = 'livesiteNotificationSettings'
+export const IS_DEVICE_IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
 export const copyText = Object.freeze({
   // CHANGE: name of hackathon to be displayed on login splash
   hackathonName: 'HackCamp 2020',


### PR DESCRIPTION
Disabled following uses of Notifications API when livesite is accessed on an IOS mobile device:
- alerting user with new announcements through push notifications
- notification toggle initialization logic

Result:
- Behaviour unchanged on desktop site + android devices? (don't own an android device so didn't test, plz enlighten me if there is reliable way to do so on desktop) 
- Notification toggle no longer visible on IOS mobile devices 
- no more crashing on mobile IOS devices 🤞 

Notes:
Correct me if I'm wrong, but it doesn't look like mobile IOS supports push notifications at all. Not sure what a proper fix would look like atm.