### PR TITLE
Added terms and conditions to HackerApplicationContext

### DIFF
--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -78,5 +78,11 @@ export const hackerApplicationTemplate = Object.freeze({
     responded: false, // using responded and attending to check if they un-RSVPed or if they didn't RSVP at all (no RSVP)
     attending: false, // false for no-rsvp by default
   },
+  termsAndConditions: {
+    MLHCodeOfConduct: false,
+    MLHPrivacyPolicy: false,
+    shareWithnwPlus: false,
+    shareWithSponsors: false,
+  },
   team: '',
 })

--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -70,7 +70,14 @@ export function HackerApplicationProvider({ children }) {
   /**Update the updated variable when making changes to the new app
      Keep the ref up to date with the latest application
      Handles merging of the current app with the new one */
-  const updateApplication = ({ basicInfo, skills, questionnaire, status, team }) => {
+  const updateApplication = ({
+    basicInfo,
+    skills,
+    questionnaire,
+    status,
+    termsAndConditions,
+    team,
+  }) => {
     const mergedApp = {
       ...application,
       basicInfo: {
@@ -88,6 +95,10 @@ export function HackerApplicationProvider({ children }) {
       status: {
         ...application.status,
         ...status,
+      },
+      termsAndConditions: {
+        ...application.termsAndConditions,
+        ...termsAndConditions,
       },
       team: team ? team : application.team,
     }


### PR DESCRIPTION
After working on the review page, I realized that we need a way to keep track of whether or not the applicant has accepted the terms and conditions at the end of the application.
As such, I've updated the application context with some new fields:
```
termsAndConditions: {
    MLHCodeOfConduct: false,  // do they accept the MLH code of conduct
    MLHPrivacyPolicy: false,    // do they accept the MLH privacy policy
    shareWithnwPlus: false,   // do they allow their data to be shared with us
    shareWithSponsors: false,   // do they allow us to share their info with sponsors
  },
```
p.s. @Ciuffi I hope this doesn't break anything!
and FYI @vincentchiang1 this probably means that autosave should be included in the review page as well 😬 
<img width="974" alt="Screen Shot 2020-12-05 at 10 49 00 PM" src="https://user-images.githubusercontent.com/38872354/101273618-12f4b000-374c-11eb-9319-e2078f6fb299.png">
