### PR TITLE
Dashboard sidebar

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -86,7 +86,8 @@ const AdminAuthPageRoute = ({ path, children }) => {
 
 /**Saves the application on logout */
 const NavbarSaveOnLogout = ({ name, handleLogout }) => {
-  const { forceSave } = useHackerApplication()
+  const { application, forceSave } = useHackerApplication()
+  // console.log(application)
   const logout = async () => {
     await forceSave()
     handleLogout()
@@ -113,6 +114,29 @@ const JudgingViewContainer = ({ params }) => {
   return isAuthed ? (
     <Page>
       <JudgingView id={params.id} />
+    </Page>
+  ) : (
+    <Redirect to="/login" />
+  )
+}
+
+const ApplicationDashboardContainer = () => {
+  const { isAuthed } = useAuth()
+  const { application } = useHackerApplication()
+
+  const hackerStatusObject = application.status
+  console.log(hackerStatusObject)
+  const hackerStatus =
+    hackerStatusObject.applicationStatus == 'accepted'
+      ? hackerStatusObject.responded
+        ? hackerStatusObject.attending
+          ? 'acceptedAndAttending'
+          : 'acceptedNotAttending'
+        : 'acceptedNoResponseYet'
+      : hackerStatusObject.applicationStatus
+  return isAuthed ? (
+    <Page hackerStatus={hackerStatus}>
+      <Application />
     </Page>
   ) : (
     <Redirect to="/login" />
@@ -183,11 +207,14 @@ function App() {
           <AuthPageRoute path="/submission">
             <Submission />
           </AuthPageRoute>
-          <AuthPageRoute path="/application">
+          {/* <AuthPageRoute path="/application">
             <HackerApplicationProvider>
               <Application />
             </HackerApplicationProvider>
-          </AuthPageRoute>
+          </AuthPageRoute> */}
+          <HackerApplicationProvider>
+            <Route path="/application" component={ApplicationDashboardContainer} />
+          </HackerApplicationProvider>
           <NavbarAuthRoute path="/application/review" name handleLogout>
             <HackerApplicationProvider>
               <ApplicationReview />

--- a/src/App.js
+++ b/src/App.js
@@ -86,8 +86,7 @@ const AdminAuthPageRoute = ({ path, children }) => {
 
 /**Saves the application on logout */
 const NavbarSaveOnLogout = ({ name, handleLogout }) => {
-  const { application, forceSave } = useHackerApplication()
-  // console.log(application)
+  const { forceSave } = useHackerApplication()
   const logout = async () => {
     await forceSave()
     handleLogout()
@@ -125,9 +124,8 @@ const ApplicationDashboardContainer = () => {
   const { application } = useHackerApplication()
 
   const hackerStatusObject = application.status
-  console.log(hackerStatusObject)
   const hackerStatus =
-    hackerStatusObject.applicationStatus == 'accepted'
+    hackerStatusObject.applicationStatus === 'accepted'
       ? hackerStatusObject.responded
         ? hackerStatusObject.attending
           ? 'acceptedAndAttending'
@@ -207,11 +205,6 @@ function App() {
           <AuthPageRoute path="/submission">
             <Submission />
           </AuthPageRoute>
-          {/* <AuthPageRoute path="/application">
-            <HackerApplicationProvider>
-              <Application />
-            </HackerApplicationProvider>
-          </AuthPageRoute> */}
           <HackerApplicationProvider>
             <Route path="/application" component={ApplicationDashboardContainer} />
           </HackerApplicationProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -134,7 +134,7 @@ const ApplicationDashboardContainer = () => {
       : hackerStatusObject.applicationStatus
   return isAuthed ? (
     <Page hackerStatus={hackerStatus}>
-      <Application />
+      <Application hackerStatus={hackerStatus} />
     </Page>
   ) : (
     <Redirect to="/login" />

--- a/src/App.js
+++ b/src/App.js
@@ -122,16 +122,16 @@ const JudgingViewContainer = ({ params }) => {
 const ApplicationDashboardContainer = () => {
   const { isAuthed } = useAuth()
   const { application } = useHackerApplication()
-
   const hackerStatusObject = application.status
   const hackerStatus =
-    hackerStatusObject.applicationStatus === 'accepted'
+    hackerStatusObject !== undefined &&
+    (hackerStatusObject.applicationStatus === 'accepted'
       ? hackerStatusObject.responded
         ? hackerStatusObject.attending
           ? 'acceptedAndAttending'
           : 'acceptedNotAttending'
         : 'acceptedNoResponseYet'
-      : hackerStatusObject.applicationStatus
+      : hackerStatusObject.applicationStatus)
   return isAuthed ? (
     <Page hackerStatus={hackerStatus}>
       <Application hackerStatus={hackerStatus} />
@@ -205,9 +205,11 @@ function App() {
           <AuthPageRoute path="/submission">
             <Submission />
           </AuthPageRoute>
-          <HackerApplicationProvider>
-            <Route path="/application" component={ApplicationDashboardContainer} />
-          </HackerApplicationProvider>
+          <Route path="/application">
+            <HackerApplicationProvider>
+              <ApplicationDashboardContainer />
+            </HackerApplicationProvider>
+          </Route>
           <NavbarAuthRoute path="/application/review" name handleLogout>
             <HackerApplicationProvider>
               <ApplicationReview />

--- a/src/App.js
+++ b/src/App.js
@@ -194,11 +194,6 @@ function App() {
           <AuthPageRoute path="/submission">
             <Submission />
           </AuthPageRoute>
-          {/* <Route path="/application">
-            <HackerApplicationProvider>
-              <ApplicationDashboardContainer />
-            </HackerApplicationProvider>
-          </Route> */}
           <Route path="/application" component={ApplicationDashboardRoutingContainer} />
           <NavbarAuthRoute path="/application/review" name handleLogout>
             <HackerApplicationProvider>

--- a/src/App.js
+++ b/src/App.js
@@ -119,23 +119,12 @@ const JudgingViewContainer = ({ params }) => {
   )
 }
 
-const ApplicationDashboardContainer = () => {
+const ApplicationDashboardRoutingContainer = () => {
   const { isAuthed } = useAuth()
-  const { application } = useHackerApplication()
-  const hackerStatusObject = application.status
-  const hackerStatus =
-    hackerStatusObject !== undefined &&
-    (hackerStatusObject.applicationStatus === 'accepted'
-      ? hackerStatusObject.responded
-        ? hackerStatusObject.attending
-          ? 'acceptedAndAttending'
-          : 'acceptedNotAttending'
-        : 'acceptedNoResponseYet'
-      : hackerStatusObject.applicationStatus)
   return isAuthed ? (
-    <Page hackerStatus={hackerStatus}>
-      <Application hackerStatus={hackerStatus} />
-    </Page>
+    <HackerApplicationProvider>
+      <Application />
+    </HackerApplicationProvider>
   ) : (
     <Redirect to="/login" />
   )
@@ -205,11 +194,12 @@ function App() {
           <AuthPageRoute path="/submission">
             <Submission />
           </AuthPageRoute>
-          <Route path="/application">
+          {/* <Route path="/application">
             <HackerApplicationProvider>
               <ApplicationDashboardContainer />
             </HackerApplicationProvider>
-          </Route>
+          </Route> */}
+          <Route path="/application" component={ApplicationDashboardRoutingContainer} />
           <NavbarAuthRoute path="/application/review" name handleLogout>
             <HackerApplicationProvider>
               <ApplicationReview />

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import { H1 } from './Typography'
 import { Button } from './Input/Button'
@@ -8,10 +8,6 @@ import instagram from '../assets/icons/instagram.svg'
 import medium from '../assets/icons/medium.svg'
 import twitter from '../assets/icons/twitter.svg'
 import { ReactComponent as HandWave } from '../assets/hand-wave.svg'
-import { useAuth } from '../utility/Auth'
-import { useHackerApplication } from '../utility/HackerApplicationContext'
-import { useLocation } from 'wouter'
-import { getLivesiteDoc } from '../utility/firebase'
 
 const Container = styled.div`
   margin: 5em auto;
@@ -136,38 +132,26 @@ const SocialMediaLinks = () => {
   )
 }
 
-const Dashboard = ({ hackerStatus }) => {
-  const { user } = useAuth()
-  const { updateApplication, forceSave } = useHackerApplication()
-  const [, setLocation] = useLocation()
-  const [livesiteDoc, setLivesiteDoc] = useState(false)
-  const canRSVP =
-    hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'
-  const setRSVP = canRSVP => {
-    updateApplication({
-      status: {
-        responded: true,
-        attending: canRSVP,
-      },
-    })
-    forceSave()
-  }
-  useEffect(() => {
-    const unsubscribe = getLivesiteDoc(setLivesiteDoc)
-    return unsubscribe
-  }, [setLivesiteDoc])
+const Dashboard = ({
+  hackerStatus,
+  isApplicationOpen,
+  canRSVP,
+  setRSVP,
+  username,
+  editApplication,
+}) => {
   return (
     <Container>
       <WelcomeHeader>
-        <WelcomeMessage>Welcome Back, {user.displayName}</WelcomeMessage>
+        <WelcomeMessage>Welcome Back, {username}</WelcomeMessage>
         <StyledHandWave />
       </WelcomeHeader>
       <AppLinks>
         <HackerAppText>YOUR HACKER APPLICATION</HackerAppText>
         <EditAppButton
           color="secondary"
-          onClick={livesiteDoc.applicationsOpen && (() => setLocation('/application/part-1'))}
-          disabled={!livesiteDoc.applicationsOpen}
+          onClick={isApplicationOpen && (() => editApplication())}
+          disabled={!isApplicationOpen}
         >
           Edit Your Application
         </EditAppButton>
@@ -195,10 +179,10 @@ const Dashboard = ({ hackerStatus }) => {
           <SocialMediaLinks />
           <RSVPButton
             width="flex"
-            onClick={livesiteDoc.applicationsOpen && (() => setRSVP(canRSVP))}
+            onClick={isApplicationOpen && (() => setRSVP(canRSVP))}
             shouldDisplay={canRSVP || hackerStatus === 'acceptedAndAttending'}
             color={canRSVP ? 'primary' : 'secondary'}
-            disabled={!livesiteDoc.applicationsOpen}
+            disabled={!isApplicationOpen}
           >
             {canRSVP ? 'RSVP' : 'un-RSVP'}
           </RSVPButton>

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -108,7 +108,6 @@ const SocialMediaIcons = styled.img`
 `
 
 const RSVPButton = styled(Button)`
-  width = 100px;
   margin-right: 0;
   ${p => p.theme.mediaQueries.mobile} {
     margin: 1em;
@@ -184,11 +183,12 @@ const Dashboard = ({ hackerStatus }) => {
         <FooterContainer>
           <SocialMediaLinks />
           <RSVPButton
+            width="flex"
             onClick={() => setRSVP(canRSVP)}
             shouldDisplay={canRSVP || hackerStatus === 'acceptedAndAttending'}
             color={canRSVP ? 'primary' : 'secondary'}
           >
-            RSVP
+            {canRSVP ? 'RSVP' : 'un-RSVP'}
           </RSVPButton>
         </FooterContainer>
       </StatusContainer>

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -161,19 +161,7 @@ const Dashboard = ({
           <AppStatusText>
             Application status: {hackerStatuses[hackerStatus]['cardText']}
           </AppStatusText>
-          <StatusBlurbText>
-            We will send out all acceptances by XX, XX, XXXX. In the mean time, get connected with
-            our community of hackers on Medium, Twitter, and Facebook to stay up to date with the
-            latest news on sponsors, prizes and workshops. We will send out all acceptances by XX,
-            XX, XXXX. In the mean time, get connected with our community of hackers on Medium,
-            Twitter, and Facebook to stay up to date with the latest news on sponsors, prizes and
-            workshops. We will send out all acceptances by XX, XX, XXXX. In the mean time, get
-            connected with our community of hackers on Medium, Twitter, and Facebook to stay up to
-            date with the latest news on sponsors, prizes and workshops. We will send out all
-            acceptances by XX, XX, XXXX. In the mean time, get connected with our community of
-            hackers on Medium, Twitter, and Facebook to stay up to date with the latest news on
-            sponsors, prizes and workshops.
-          </StatusBlurbText>
+          <StatusBlurbText>{hackerStatuses[hackerStatus]['blurb']}</StatusBlurbText>
         </div>
         <FooterContainer>
           <SocialMediaLinks />

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { H1 } from './Typography'
 import { Button } from './Input/Button'
@@ -11,6 +11,7 @@ import { ReactComponent as HandWave } from '../assets/hand-wave.svg'
 import { useAuth } from '../utility/Auth'
 import { useHackerApplication } from '../utility/HackerApplicationContext'
 import { useLocation } from 'wouter'
+import { getLivesiteDoc } from '../utility/firebase'
 
 const Container = styled.div`
   margin: 5em auto;
@@ -137,8 +138,9 @@ const SocialMediaLinks = () => {
 
 const Dashboard = ({ hackerStatus }) => {
   const { user } = useAuth()
-  const { updateApplication } = useHackerApplication()
+  const { updateApplication, forceSave } = useHackerApplication()
   const [, setLocation] = useLocation()
+  const [livesiteDoc, setLivesiteDoc] = useState(false)
   const canRSVP =
     hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'
   const setRSVP = canRSVP => {
@@ -148,7 +150,12 @@ const Dashboard = ({ hackerStatus }) => {
         attending: canRSVP,
       },
     })
+    forceSave()
   }
+  useEffect(() => {
+    const unsubscribe = getLivesiteDoc(setLivesiteDoc)
+    return unsubscribe
+  }, [setLivesiteDoc])
   return (
     <Container>
       <WelcomeHeader>
@@ -157,7 +164,11 @@ const Dashboard = ({ hackerStatus }) => {
       </WelcomeHeader>
       <AppLinks>
         <HackerAppText>YOUR HACKER APPLICATION</HackerAppText>
-        <EditAppButton color="secondary" onClick={() => setLocation('/application/part-1')}>
+        <EditAppButton
+          color="secondary"
+          onClick={livesiteDoc.applicationsOpen && (() => setLocation('/application/part-1'))}
+          disabled={!livesiteDoc.applicationsOpen}
+        >
           Edit Your Application
         </EditAppButton>
       </AppLinks>
@@ -184,9 +195,10 @@ const Dashboard = ({ hackerStatus }) => {
           <SocialMediaLinks />
           <RSVPButton
             width="flex"
-            onClick={() => setRSVP(canRSVP)}
+            onClick={livesiteDoc.applicationsOpen && (() => setRSVP(canRSVP))}
             shouldDisplay={canRSVP || hackerStatus === 'acceptedAndAttending'}
             color={canRSVP ? 'primary' : 'secondary'}
+            disabled={!livesiteDoc.applicationsOpen}
           >
             {canRSVP ? 'RSVP' : 'un-RSVP'}
           </RSVPButton>

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -9,6 +9,7 @@ import medium from '../assets/icons/medium.svg'
 import twitter from '../assets/icons/twitter.svg'
 import { ReactComponent as HandWave } from '../assets/hand-wave.svg'
 import { useAuth } from '../utility/Auth'
+import { useHackerApplication } from '../utility/HackerApplicationContext'
 import { useLocation } from 'wouter'
 
 const Container = styled.div`
@@ -37,6 +38,9 @@ const WelcomeMessage = styled(H1)`
 const StyledHandWave = styled(HandWave)`
   margin-left: 10px;
   margin-top: 20px;
+  ${p => p.theme.mediaQueries.mobile} {
+    margin-top: 10px;
+  }
 `
 
 const AppLinks = styled.div`
@@ -109,6 +113,7 @@ const RSVPButton = styled(Button)`
   ${p => p.theme.mediaQueries.mobile} {
     margin: 1em;
   }
+  ${p => !p.shouldDisplay && 'display: none'}
 `
 
 const SocialMediaLinks = () => {
@@ -133,9 +138,18 @@ const SocialMediaLinks = () => {
 
 const Dashboard = ({ hackerStatus }) => {
   const { user } = useAuth()
+  const { updateApplication } = useHackerApplication()
   const [, setLocation] = useLocation()
-  console.log(hackerStatus)
-  console.log(hackerStatuses)
+  const canRSVP =
+    hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'
+  const setRSVP = canRSVP => {
+    updateApplication({
+      status: {
+        responded: true,
+        attending: canRSVP,
+      },
+    })
+  }
   return (
     <Container>
       <WelcomeHeader>
@@ -169,7 +183,13 @@ const Dashboard = ({ hackerStatus }) => {
         </div>
         <FooterContainer>
           <SocialMediaLinks />
-          <RSVPButton color="primary">RSVP</RSVPButton>
+          <RSVPButton
+            onClick={() => setRSVP(canRSVP)}
+            shouldDisplay={canRSVP || hackerStatus === 'acceptedAndAttending'}
+            color={canRSVP ? 'primary' : 'secondary'}
+          >
+            RSVP
+          </RSVPButton>
         </FooterContainer>
       </StatusContainer>
     </Container>

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -2,12 +2,14 @@ import React from 'react'
 import styled from 'styled-components'
 import { H1 } from './Typography'
 import { Button } from './Input/Button'
-import { SOCIAL_LINKS } from '../utility/Constants'
+import { SOCIAL_LINKS, hackerStatuses } from '../utility/Constants'
 import facebook from '../assets/icons/facebook.svg'
 import instagram from '../assets/icons/instagram.svg'
 import medium from '../assets/icons/medium.svg'
 import twitter from '../assets/icons/twitter.svg'
 import { ReactComponent as HandWave } from '../assets/hand-wave.svg'
+import { useAuth } from '../utility/Auth'
+import { useLocation } from 'wouter'
 
 const Container = styled.div`
   margin: 5em auto;
@@ -55,7 +57,7 @@ const EditAppButton = styled(Button)`
 
 const StatusContainer = styled.div`
   min-height: 350px;
-  padding: 2.5em 4.5em 2.5em 3em;
+  padding: 2.5em 4.5em;
   ${p => p.theme.mediaQueries.mobile} {
     padding: 2em;
   }
@@ -129,20 +131,28 @@ const SocialMediaLinks = () => {
   )
 }
 
-const Dashboard = () => {
+const Dashboard = ({ hackerStatus }) => {
+  const { user } = useAuth()
+  const [, setLocation] = useLocation()
+  console.log(hackerStatus)
+  console.log(hackerStatuses)
   return (
     <Container>
       <WelcomeHeader>
-        <WelcomeMessage>Welcome Back, INSERT_NAME!</WelcomeMessage>
+        <WelcomeMessage>Welcome Back, {user.displayName}</WelcomeMessage>
         <StyledHandWave />
       </WelcomeHeader>
       <AppLinks>
         <HackerAppText>YOUR HACKER APPLICATION</HackerAppText>
-        <EditAppButton color="secondary">Edit Your Application</EditAppButton>
+        <EditAppButton color="secondary" onClick={() => setLocation('/application/part-1')}>
+          Edit Your Application
+        </EditAppButton>
       </AppLinks>
       <StatusContainer>
         <div>
-          <AppStatusText>Application status: APP_STATUS</AppStatusText>
+          <AppStatusText>
+            Application status: {hackerStatuses[hackerStatus]['cardText']}
+          </AppStatusText>
           <StatusBlurbText>
             We will send out all acceptances by XX, XX, XXXX. In the mean time, get connected with
             our community of hackers on Medium, Twitter, and Facebook to stay up to date with the

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -57,8 +57,7 @@ const EditAppButton = styled(Button)`
 `
 
 const StatusContainer = styled.div`
-  min-height: 350px;
-  padding: 2.5em 4.5em;
+  padding: 3em 3em 2em;
   ${p => p.theme.mediaQueries.mobile} {
     padding: 2em;
   }
@@ -150,6 +149,7 @@ const Dashboard = ({
         <HackerAppText>YOUR HACKER APPLICATION</HackerAppText>
         <EditAppButton
           color="secondary"
+          height="short"
           onClick={isApplicationOpen && (() => editApplication())}
           disabled={!isApplicationOpen}
         >

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -24,7 +24,7 @@ const Content = styled.div`
   }
 `
 
-const Page = ({ children }) => {
+const Page = ({ hackerStatus, children }) => {
   const [showMobileSidebar, setShowMobileSidebar] = useState(false)
   const [livesiteDoc, setLivesiteDoc] = useState(false)
 
@@ -40,6 +40,7 @@ const Page = ({ children }) => {
         isSubmissionsOpen={livesiteDoc.submissionsOpen}
         isApplicationOpen={livesiteDoc.applicationsOpen}
         showMobileSidebar={showMobileSidebar}
+        hackerStatus={hackerStatus}
       />
       <RightContentContainer>
         <MobileMenuBar

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -85,6 +85,7 @@ const ApplicationText = styled.div`
 
 const StatusText = styled.div`
   font-size: 0.8em;
+  color: ${p => p.theme.colors.primary};
   margin-top: 5px;
 `
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -6,6 +6,7 @@ import logo from '../assets/logo.svg'
 import hc_logo from '../assets/hc_logo.svg'
 import { Button } from './Input/index'
 import { useAuth } from '../utility/Auth'
+import { hackerStatuses } from '../utility/Constants'
 
 const SidebarContainer = styled.div`
   min-width: 275px;
@@ -78,7 +79,19 @@ const StyledButton = styled(Button)`
   margin: 1em 0 2em 60px;
 `
 
-export default ({ showMobileSidebar, isJudgingOpen, isSubmissionsOpen, isApplicationOpen }) => {
+const StatusText = styled.div`
+  font-size: 0.8em;
+  color: ${p => p.theme.colors.primary};
+  margin-top: 5px;
+`
+
+export default ({
+  showMobileSidebar,
+  isJudgingOpen,
+  isSubmissionsOpen,
+  isApplicationOpen,
+  hackerStatus,
+}) => {
   const [location] = useLocation()
   const { isAuthed, logout } = useAuth()
   const links = [
@@ -115,13 +128,23 @@ export default ({ showMobileSidebar, isJudgingOpen, isSubmissionsOpen, isApplica
         LIVE
       </LiveLabel>
       <ItemsContainer>
-        {links.map((link, i) => {
-          return (
-            <Link key={i} href={link.location}>
-              <StyledA selected={location === link.location}>{link.text}</StyledA>
-            </Link>
-          )
-        })}
+        {!hackerStatus || hackerStatus === 'acceptedAndAttending' ? (
+          links.map((link, i) => {
+            return (
+              <Link key={i} href={link.location}>
+                <StyledA selected={location === link.location}>{link.text}</StyledA>
+              </Link>
+            )
+          })
+        ) : (
+          // Not sure if I should abstract this case to use links.map
+          <Link href={'/application'}>
+            <StyledA selected={location === '/application'}>
+              APPLICATION
+              <StatusText>{hackerStatuses[hackerStatus]['sidebarText']}</StatusText>
+            </StyledA>
+          </Link>
+        )}
       </ItemsContainer>
       {isAuthed && (
         <StyledButton color="secondary" onClick={logout}>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -14,7 +14,7 @@ const SidebarContainer = styled.div`
   border-right: 1px solid ${p => p.theme.colors.border};
   transition: opacity 1s ease-out;
   ${p => p.theme.mediaQueries.mobile} {
-    ${p => (p.showMobileSidebar ? 'visibility: visible' : 'display: none')};
+    ${p => (p.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none')};
   }
 `
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -14,7 +14,7 @@ const SidebarContainer = styled.div`
   border-right: 1px solid ${p => p.theme.colors.border};
   transition: opacity 1s ease-out;
   ${p => p.theme.mediaQueries.mobile} {
-    ${p => (p.showMobileSidebar ? 'visibility: visible' : 'visibility: hidden; display: none')};
+    ${p => (p.showMobileSidebar ? 'visibility: visible' : 'display: none')};
   }
 `
 
@@ -79,9 +79,12 @@ const StyledButton = styled(Button)`
   margin: 1em 0 2em 60px;
 `
 
+const ApplicationText = styled.div`
+  color: #ffffff;
+`
+
 const StatusText = styled.div`
   font-size: 0.8em;
-  color: ${p => p.theme.colors.primary};
   margin-top: 5px;
 `
 
@@ -140,7 +143,7 @@ export default ({
           // Not sure if I should abstract this case to use links.map
           <Link href={'/application'}>
             <StyledA selected={location === '/application'}>
-              APPLICATION
+              <ApplicationText>APPLICATION</ApplicationText>
               <StatusText>{hackerStatuses[hackerStatus]['sidebarText']}</StatusText>
             </StyledA>
           </Link>

--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -1,0 +1,57 @@
+import React, { useState, useEffect } from 'react'
+import Dashboard from '../../components/ApplicationDashboard'
+import { useHackerApplication } from '../../utility/HackerApplicationContext'
+import { useAuth } from '../../utility/Auth'
+import { useLocation } from 'wouter'
+import { getLivesiteDoc } from '../../utility/firebase'
+import Page from '../../components/Page'
+
+const ApplicationDashboardContainer = () => {
+  const { application, updateApplication, forceSave } = useHackerApplication()
+  const [livesiteDoc, setLivesiteDoc] = useState(false)
+  const { user } = useAuth()
+  const [, setLocation] = useLocation()
+
+  const hackerStatusObject = application.status
+  const hackerStatus =
+    hackerStatusObject !== undefined &&
+    (hackerStatusObject.applicationStatus === 'accepted'
+      ? hackerStatusObject.responded
+        ? hackerStatusObject.attending
+          ? 'acceptedAndAttending'
+          : 'acceptedNotAttending'
+        : 'acceptedNoResponseYet'
+      : hackerStatusObject.applicationStatus)
+
+  const canRSVP =
+    hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'
+  const setRSVP = canRSVP => {
+    updateApplication({
+      status: {
+        responded: true,
+        attending: canRSVP,
+      },
+    })
+    forceSave()
+  }
+
+  useEffect(() => {
+    const unsubscribe = getLivesiteDoc(setLivesiteDoc)
+    return unsubscribe
+  }, [setLivesiteDoc])
+
+  return (
+    <Page hackerStatus={hackerStatus}>
+      <Dashboard
+        editApplication={() => setLocation('/application/part-1')}
+        username={user.displayName}
+        hackerStatus={hackerStatus}
+        isApplicationOpen={livesiteDoc.applicationsOpen}
+        setRSVP={() => setRSVP(canRSVP)}
+        canRSVP={canRSVP}
+      />
+    </Page>
+  )
+}
+
+export default ApplicationDashboardContainer

--- a/src/pages/Application/index.js
+++ b/src/pages/Application/index.js
@@ -2,6 +2,6 @@ import React from 'react'
 import Dashboard from '../../components/ApplicationDashboard'
 
 // applicant dashboard
-export default () => {
-  return <Dashboard />
+export default ({ hackerStatus }) => {
+  return <Dashboard hackerStatus={hackerStatus} />
 }

--- a/src/pages/Application/index.js
+++ b/src/pages/Application/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Dashboard from '../../components/ApplicationDashboard'
+import Dashboard from '../../containers/Application/Dashboard'
 
 // applicant dashboard
 export default ({ hackerStatus }) => {

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -1,3 +1,4 @@
+import React from 'react'
 export const DB_COLLECTION = 'Hackathons'
 
 // CHANGE: firebase collection name for this hackathon
@@ -123,7 +124,14 @@ export const hackerStatuses = {
       "Congratulations! We loved the passion and drive we saw in your application, and we'd love even more for you to join us at nwHacks 2021 over the weekend of January XX-XX! RSVP before January Xth at 11:59 PM to confirm your spot.",
   },
   acceptedAndAttending: {
-    cardText: "Accepted & RSVP'd",
+    cardText: (
+      <>
+        Accepted & RSVP'd{' '}
+        <span role="img" aria-label="celebrate emoji">
+          🎊
+        </span>
+      </>
+    ),
     blurb:
       "We can't wait to see you at nwHacks! You'll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can't make it to nwHacks anymore due to change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers!",
   },

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -96,3 +96,29 @@ export const hackerApplicationTemplate = Object.freeze({
   },
   team: '',
 })
+
+export const hackerStatuses = {
+  applied: {
+    sidebarText: 'In Review',
+    cardText: 'Awaiting assessment',
+  },
+  waitlisted: {
+    sidebarText: 'Waitlisted',
+    cardText: 'Waitlisted',
+  },
+  rejected: {
+    sidebarText: 'Rejected',
+    cardText: 'Rejected',
+  },
+  acceptedNoResponseYet: {
+    sidebarText: 'Accepted, Awaiting RSVP',
+    cardText: 'Accepted & Awaiting RSVP',
+  },
+  acceptedAndAttending: {
+    cardText: "Accepted & RSVP'd",
+  },
+  acceptedNotAttending: {
+    sidebarText: "Un-RSVP'd",
+    cardText: "Un-RSVP'd",
+  },
+}

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -101,30 +101,36 @@ export const hackerStatuses = {
   applied: {
     sidebarText: 'In Review',
     cardText: 'Awaiting assessment',
-    blurb: 'We will send out all acceptances by XX, XX, XXXX. In the mean time, get connected with our community of hackers on Medium, Twitter, and Facebook to stay up to date with the latest news on sponsors, prizes and workshops.',
+    blurb:
+      'We will send out all acceptances by XX, XX, XXXX. In the mean time, get connected with our community of hackers on Medium, Twitter, and Facebook to stay up to date with the latest news on sponsors, prizes and workshops.',
   },
   waitlisted: {
     sidebarText: 'Waitlisted',
     cardText: 'Waitlisted',
-    blurb: 'Hi Haku, we had a lovely time reading your application, and  were very impressed with your commitment to joining the technology community. We would love to see you at nwHacks this year, however, at the moment, we can not confirm a spot for you. You have been put in our waitlist, and will be notified within ___ if we found a spot for you, so please check your email then!',
+    blurb:
+      'Hi Haku, we had a lovely time reading your application, and  were very impressed with your commitment to joining the technology community. We would love to see you at nwHacks this year, however, at the moment, we can not confirm a spot for you. You have been put in our waitlist, and will be notified within ___ if we found a spot for you, so please check your email then!',
   },
   rejected: {
     sidebarText: 'Rejected',
     cardText: 'Rejected',
-    blurb: 'Hi Haku, we are sorry to inform you that we won't be able to give you a spot at nwHacks 2021. We had a lot of amazing applicants this year, and we are very grateful to have gotten yours, but we can't take everyone. We do hope to see your application next year and that this setback isn't the end of your tech career. Please visit our site nwplus.io to learn about more events and other ways to engage with the technology community.',
+    blurb:
+      "Hi Haku, we are sorry to inform you that we won't be able to give you a spot at nwHacks 2021. We had a lot of amazing applicants this year, and we are very grateful to have gotten yours, but we can't take everyone. We do hope to see your application next year and that this setback isn't the end of your tech career. Please visit our site nwplus.io to learn about more events and other ways to engage with the technology community.",
   },
   acceptedNoResponseYet: {
     sidebarText: 'Accepted, Awaiting RSVP',
     cardText: 'Accepted & Awaiting RSVP',
-    blurb: 'Congratulations! We loved the passion and drive we saw in your application, and we'd love even more for you to join us at nwHacks 2021 over the weekend of January XX-XX! RSVP before January Xth at 11:59 PM to confirm your spot.',
+    blurb:
+      "Congratulations! We loved the passion and drive we saw in your application, and we'd love even more for you to join us at nwHacks 2021 over the weekend of January XX-XX! RSVP before January Xth at 11:59 PM to confirm your spot.",
   },
   acceptedAndAttending: {
     cardText: "Accepted & RSVP'd",
-    blurb: 'We can’t wait to see you at nwHacks! You’ll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can’t make it to nwHacks anymore due to change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers! ',
+    blurb:
+      "We can't wait to see you at nwHacks! You'll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can't make it to nwHacks anymore due to change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers!",
   },
   acceptedNotAttending: {
     sidebarText: "Un-RSVP'd",
     cardText: "Un-RSVP'd",
-    blurb: 'We’re sorry you won’t be attending nwHacks this year. We do hope to see you at our future events, visit our site nwplus.io or follow us on social media to learn about our events and other ways to engage with the technology community!',
+    blurb:
+      "We're sorry you won't be attending nwHacks this year. We do hope to see you at our future events, visit our site nwplus.io or follow us on social media to learn about our events and other ways to engage with the technology community!",
   },
 }

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -126,7 +126,7 @@ export const hackerStatuses = {
   acceptedAndAttending: {
     cardText: (
       <>
-        Accepted & RSVP'd{' '}
+        Accepted &amp; RSVP'd{' '}
         <span role="img" aria-label="celebrate emoji">
           🎊
         </span>

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -101,24 +101,30 @@ export const hackerStatuses = {
   applied: {
     sidebarText: 'In Review',
     cardText: 'Awaiting assessment',
+    blurb: 'We will send out all acceptances by XX, XX, XXXX. In the mean time, get connected with our community of hackers on Medium, Twitter, and Facebook to stay up to date with the latest news on sponsors, prizes and workshops.',
   },
   waitlisted: {
     sidebarText: 'Waitlisted',
     cardText: 'Waitlisted',
+    blurb: 'Hi Haku, we had a lovely time reading your application, and  were very impressed with your commitment to joining the technology community. We would love to see you at nwHacks this year, however, at the moment, we can not confirm a spot for you. You have been put in our waitlist, and will be notified within ___ if we found a spot for you, so please check your email then!',
   },
   rejected: {
     sidebarText: 'Rejected',
     cardText: 'Rejected',
+    blurb: 'Hi Haku, we are sorry to inform you that we won't be able to give you a spot at nwHacks 2021. We had a lot of amazing applicants this year, and we are very grateful to have gotten yours, but we can't take everyone. We do hope to see your application next year and that this setback isn't the end of your tech career. Please visit our site nwplus.io to learn about more events and other ways to engage with the technology community.',
   },
   acceptedNoResponseYet: {
     sidebarText: 'Accepted, Awaiting RSVP',
     cardText: 'Accepted & Awaiting RSVP',
+    blurb: 'Congratulations! We loved the passion and drive we saw in your application, and we'd love even more for you to join us at nwHacks 2021 over the weekend of January XX-XX! RSVP before January Xth at 11:59 PM to confirm your spot.',
   },
   acceptedAndAttending: {
     cardText: "Accepted & RSVP'd",
+    blurb: 'We can’t wait to see you at nwHacks! You’ll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can’t make it to nwHacks anymore due to change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers! ',
   },
   acceptedNotAttending: {
     sidebarText: "Un-RSVP'd",
     cardText: "Un-RSVP'd",
+    blurb: 'We’re sorry you won’t be attending nwHacks this year. We do hope to see you at our future events, visit our site nwplus.io or follow us on social media to learn about our events and other ways to engage with the technology community!',
   },
 }

--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -120,9 +120,9 @@ export function HackerApplicationProvider({ children }) {
    */
   return applicationOpen === null || application === undefined ? (
     <Spinner />
-  ) : !applicationOpen ? (
-    <Page>Applications are closed.</Page>
   ) : (
+    // ) : !applicationOpen ? (
+    //   <Page>Applications are closed.</Page>
     <HackerApplicationContext.Provider value={{ application, updateApplication, forceSave }}>
       {children}
     </HackerApplicationContext.Provider>

--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -3,7 +3,7 @@ import { useAuth } from './Auth'
 import { getUserApplication, updateUserApplication, getLivesiteDoc } from './firebase'
 import firebase from 'firebase/app'
 import Spinner from '../components/Loading'
-import Page from '../components/Page'
+// import Page from '../components/Page'
 const HackerApplicationContext = createContext()
 
 export function useHackerApplication() {

--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -121,6 +121,7 @@ export function HackerApplicationProvider({ children }) {
   return applicationOpen === null || application === undefined ? (
     <Spinner />
   ) : (
+    // Commented out temporarily, will determine behaviour when application isn't open later
     // ) : !applicationOpen ? (
     //   <Page>Applications are closed.</Page>
     <HackerApplicationContext.Provider value={{ application, updateApplication, forceSave }}>


### PR DESCRIPTION
## Issues Closed: 
Closes #117 #125 (these 2 are pretty much the same) and #116.

## What was added:
1. The sidebar of the application dashboard page will show different messages depending on the hacker's status (unless the hacker is attending the event, then the sidebar will just be the normal one)
2. The edit button will take hacker to the first part of their application
3. When the hacker has been accepted, the RSVP button will be present and can be used to RSVP and un-RSVP
4. The above 2 buttons will be disabled when applications are closed

## Notes:
1. There was a page displayed specifically when applications are closed in the `HackerAppContext`, I have commented that out for now to test the behaviour of the edit and RSVP button. 
2. When a hacker hasn't submitted their application and tries to go to `/application`, a redirect will take them to part 1 of their application. So the dashboard implementation assumes the current user will not have the status of `inProgress`. However, the redirect seems to be a bit bugged now and won't trigger when the user directly goes to `/application`. 

## How to test:
1. Go to `/application` directly
2. Go to your entry in the applications array in the db
3. Change the values in the status object of your application and reload the page to see the changes
4. You can also go to the livesite doc and change `applicationsOpen` to test if the buttons are disabled

There are 6 total states you can try. Below is a list of values of the status variables to trigger different states:
1. *Applied* -> `applicationStatus == "applied"`
2. *Rejected* -> `applicationStatus == "rejected"`
3. *Waitlisted* -> `applicationStatus == "waitlisted"`
4. *Accepted with no response yet* -> `applicationStatus == "accepted", !attending, !responded`
5. *Accepted and RSVP'ed* -> `applicationStatus == "accepted", attending, responded`
6. *Accepted and un-RSVP'ed* -> `applicationStatus == "accepted", !attending, responded`