### PR TITLE
UI fixes, change to hackathon name and db

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>HackCamp Portal</title>
+    <title>nwHacks Portal</title>
   </head>
 
   <body>

--- a/src/components/ApplicationForm/BasicInfo.js
+++ b/src/components/ApplicationForm/BasicInfo.js
@@ -167,7 +167,7 @@ export default ({ formInputs, onChange }) => (
         options={schools}
         placeholder="Enter your school"
         isSearchable
-        formatCreateLabel={inputValue => `My school is not listed, use "${inputValue}"`}
+        formatCreateLabel={inputValue => `${inputValue}`}
         label={formInputs.school}
         value={creatableDropdownValue(schools, 'label', formInputs.school)}
         onChange={e =>
@@ -188,7 +188,7 @@ export default ({ formInputs, onChange }) => (
         options={majors}
         placeholder="Enter your major"
         isSearchable
-        formatCreateLabel={inputValue => `My major is not listed, use "${inputValue}"`}
+        formatCreateLabel={inputValue => `${inputValue}`}
         label={formInputs.major}
         value={creatableDropdownValue(majors, 'label', formInputs.major)}
         onChange={e =>

--- a/src/components/ApplicationForm/BasicInfo.js
+++ b/src/components/ApplicationForm/BasicInfo.js
@@ -1,9 +1,9 @@
 import React from 'react'
-import { H1, QuestionHeading, CenteredH1 } from '../Typography'
+import { QuestionHeading, CenteredH1 } from '../Typography'
 import { TextInput } from '../Input/TextInput'
 import Dropdown from '../Input/Dropdown'
 import Select from '../Input/Select'
-import { FormSpacing } from '../ApplicationForm/index'
+import { FormSpacing, SubHeading } from './'
 import schools from '../../containers/Application/data/schools.json'
 import majors from '../../containers/Application/data/majors.json'
 import { findElement, creatableDropdownValue } from '../../utility/utilities'
@@ -67,7 +67,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 01</QuestionHeading>
-      <H1 size="1.5em">What is your preferred name?</H1>
+      <SubHeading>What is your preferred name?</SubHeading>
       <TextInput
         placeholder="First Name"
         inline
@@ -92,7 +92,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 02</QuestionHeading>
-      <H1 size="1.5em">Which gender do you identify as?</H1>
+      <SubHeading>Which gender do you identify as?</SubHeading>
       <Dropdown
         options={genderOptions}
         placeholder="Gender"
@@ -110,24 +110,26 @@ export default ({ formInputs, onChange }) => (
     {/* TODO: the mapping of formInputs.ethnicity is causing errors */}
     <FormSpacing>
       <QuestionHeading>question 03</QuestionHeading>
-      <H1 size="1.5em">What is your race/ethnicity? (Select all that apply)</H1>
-      {Object.entries(formInputs.ethnicity).map(([key, val]) => (
-        <Select
-          type="checkbox"
-          label={ethnicityOptions[key]}
-          checked={val}
-          onChange={() =>
-            onChange({
-              ethnicity: { ...formInputs.ethnicity, [key]: !val },
-            })
-          }
-        />
-      ))}
+      <SubHeading>What is your race/ethnicity? (Select all that apply)</SubHeading>
+      {Object.entries(formInputs.ethnicity)
+        .sort()
+        .map(([key, val]) => (
+          <Select
+            type="checkbox"
+            label={ethnicityOptions[key]}
+            checked={val}
+            onChange={() =>
+              onChange({
+                ethnicity: { ...formInputs.ethnicity, [key]: !val },
+              })
+            }
+          />
+        ))}
     </FormSpacing>
 
     <FormSpacing>
       <QuestionHeading>question 04</QuestionHeading>
-      <H1 size="1.5em">Will you be 19 years or older by January 9th, 2021?</H1>
+      <SubHeading>Will you be 19 years or older by January 9th, 2021?</SubHeading>
       <Select
         type="radio"
         label="Yes"
@@ -144,7 +146,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 05</QuestionHeading>
-      <H1 size="1.5em">What is your phone number?</H1>
+      <SubHeading>What is your phone number?</SubHeading>
       <TextInput
         placeholder="XXX-XXX-XXXX"
         value={formInputs.phoneNumber}
@@ -153,13 +155,14 @@ export default ({ formInputs, onChange }) => (
             phoneNumber: e.target.value,
           })
         }
+        inline
       />
       {/* validation check is num */}
     </FormSpacing>
 
     <FormSpacing>
       <QuestionHeading>question 06</QuestionHeading>
-      <H1 size="1.5em">What school do you go to?</H1>
+      <SubHeading>What school do you go to?</SubHeading>
       <Dropdown
         options={schools}
         placeholder="Enter your school"
@@ -180,7 +183,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 07</QuestionHeading>
-      <H1 size="1.5em">What is your current or intended major?</H1>
+      <SubHeading>What is your current or intended major?</SubHeading>
       <Dropdown
         options={majors}
         placeholder="Enter your major"
@@ -201,7 +204,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 08</QuestionHeading>
-      <H1 size="1.5em">What is your current level of education?</H1>
+      <SubHeading>What is your current level of education?</SubHeading>
       <Dropdown
         options={educationOptions}
         placeholder="Level of Education"
@@ -218,7 +221,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 09</QuestionHeading>
-      <H1 size="1.5em">What is your graduation year?</H1>
+      <SubHeading>What is your graduation year?</SubHeading>
       <Dropdown
         options={graduationOptions}
         placeholder="Graduation Year"
@@ -235,7 +238,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 10</QuestionHeading>
-      <H1 size="1.5em">How many hackathons have you attended (both online and in-person)?</H1>
+      <SubHeading>How many hackathons have you attended (both online and in-person)?</SubHeading>
       <Dropdown
         options={hackathonOptions}
         placeholder="Number of Hackathons"
@@ -252,10 +255,10 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 11</QuestionHeading>
-      <H1 size="1.5em">
+      <SubHeading>
         How do you want to contribute at nwHacks? Please select the category that you're strongest
         in.
-      </H1>
+      </SubHeading>
       <Select
         type="radio"
         label="Developer"
@@ -272,7 +275,7 @@ export default ({ formInputs, onChange }) => (
 
     <FormSpacing>
       <QuestionHeading>question 12</QuestionHeading>
-      <H1 size="1.5em">Where are you currently located?</H1>
+      <SubHeading>Where are you currently located?</SubHeading>
       <TextInput
         placeholder="Enter your city and country"
         value={formInputs.location}
@@ -281,6 +284,7 @@ export default ({ formInputs, onChange }) => (
             location: e.target.value,
           })
         }
+        inline
       />
     </FormSpacing>
   </>

--- a/src/components/ApplicationForm/BasicInfo.js
+++ b/src/components/ApplicationForm/BasicInfo.js
@@ -107,24 +107,24 @@ export default ({ formInputs, onChange }) => (
       />
     </FormSpacing>
 
-    {/* TODO: the mapping of formInputs.ethnicity is causing errors */}
     <FormSpacing>
       <QuestionHeading>question 03</QuestionHeading>
       <SubHeading>What is your race/ethnicity? (Select all that apply)</SubHeading>
-      {Object.entries(formInputs.ethnicity)
-        .sort()
-        .map(([key, val]) => (
-          <Select
-            type="checkbox"
-            label={ethnicityOptions[key]}
-            checked={val}
-            onChange={() =>
-              onChange({
-                ethnicity: { ...formInputs.ethnicity, [key]: !val },
-              })
-            }
-          />
-        ))}
+      {formInputs &&
+        Object.entries(formInputs?.ethnicity)
+          .sort()
+          .map(([key, val]) => (
+            <Select
+              type="checkbox"
+              label={ethnicityOptions[key]}
+              checked={val}
+              onChange={() =>
+                onChange({
+                  ethnicity: { ...formInputs.ethnicity, [key]: !val },
+                })
+              }
+            />
+          ))}
     </FormSpacing>
 
     <FormSpacing>

--- a/src/components/ApplicationForm/Questionnaire.js
+++ b/src/components/ApplicationForm/Questionnaire.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Dropdown, Select, TextInput } from '../../components/Input'
 import { H1, QuestionHeading } from '../../components/Typography'
-import { FormSpacing } from './index'
+import { FormSpacing, SubHeading } from './'
 import { CenteredH1 } from '../Typography'
 import { findElement } from '../../utility/utilities'
 
@@ -27,15 +27,17 @@ export const options = [
 export default ({ formInputs, onChange }) => {
   return (
     <>
-      <CenteredH1>
-        Almost there...{' '}
-        <span role="img" aria-label="Ghost emoji">
-          👻
-        </span>
-      </CenteredH1>
+      <FormSpacing>
+        <CenteredH1>
+          Almost there...{' '}
+          <span role="img" aria-label="Ghost emoji">
+            👻
+          </span>
+        </CenteredH1>
+      </FormSpacing>
       <FormSpacing>
         <QuestionHeading>Question 14</QuestionHeading>
-        <H1 size="1.5em">How did you hear about nwHacks?</H1>
+        <SubHeading>How did you hear about nwHacks?</SubHeading>
         <StyledDropdown
           options={options}
           placeholder={'Select an option'}
@@ -68,7 +70,7 @@ export default ({ formInputs, onChange }) => {
 
       <FormSpacing>
         <QuestionHeading>Question 15</QuestionHeading>
-        <H1 size="1.5em">Which nwPlus events have you been to? (Select all that apply)</H1>
+        <SubHeading>Which nwPlus events have you been to? (Select all that apply)</SubHeading>
         <Select
           type="checkbox"
           label="Local Hack Day / Hack Camp"

--- a/src/components/ApplicationForm/Questionnaire.js
+++ b/src/components/ApplicationForm/Questionnaire.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Dropdown, Select, TextInput } from '../../components/Input'
-import { H1, QuestionHeading } from '../../components/Typography'
+import { QuestionHeading } from '../../components/Typography'
 import { FormSpacing, SubHeading } from './'
 import { CenteredH1 } from '../Typography'
 import { findElement } from '../../utility/utilities'

--- a/src/components/ApplicationForm/ReviewCards.js
+++ b/src/components/ApplicationForm/ReviewCards.js
@@ -188,7 +188,14 @@ export default ({ formInputs, handleEdit, onChange }) => {
         </JohnDiv>
         <StyledBanner wide={true} blur>
           <ContentWrapper>
-            <InfoGroup heading="Resume" data={formInputs.skills.resume.match(/[/\\]([\w\d\s.\-()]+)$/)[1]} />
+            <InfoGroup
+              heading="Resume"
+              data={
+                (formInputs.skills.resume &&
+                  formInputs.skills.resume.match(/[/\\]([\w\d\s.\-()]+)$/)[1]) ||
+                ''
+              }
+            />
             <InfoGroup heading="Portfolio" data={formInputs.skills.portfolio} />
             <InfoGroup heading="LinkedIn" data={formInputs.skills.linkedin} />
             <InfoGroup heading="GitHub" data={formInputs.skills.github} />

--- a/src/components/ApplicationForm/ReviewCards.js
+++ b/src/components/ApplicationForm/ReviewCards.js
@@ -191,9 +191,9 @@ export default ({ formInputs, handleEdit, onChange }) => {
             <InfoGroup
               heading="Resume"
               data={
-                (formInputs.skills.resume &&
-                  formInputs.skills.resume.match(/[/\\]([\w\d\s.\-()]+)$/)[1]) ||
-                ''
+                formInputs.skills.resume
+                  ? formInputs.skills.resume.match(/[/\\]([\w\d\s.\-()]+)$/)[1]
+                  : ''
               }
             />
             <InfoGroup heading="Portfolio" data={formInputs.skills.portfolio} />

--- a/src/components/ApplicationForm/Skills.js
+++ b/src/components/ApplicationForm/Skills.js
@@ -39,7 +39,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
         <CenteredH1>
           Flex your skills!{' '}
           <span role="img" aria-label="muscle">
-            &#128170;
+            💪
           </span>
         </CenteredH1>
       </FormSpacing>
@@ -50,7 +50,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
           {' '}
           Don't be shy! Show off your wonderful skills{' '}
           <span role="img" aria-label="smiling face">
-            &#128513;
+            😁
           </span>
         </SubHeading>
         <H3>

--- a/src/components/ApplicationForm/Skills.js
+++ b/src/components/ApplicationForm/Skills.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { CenteredH1, H1, H2, QuestionHeading } from '../Typography'
+import { CenteredH1, H1, H3, QuestionHeading } from '../Typography'
 import { TextInput, TextArea } from '../Input'
 import ResumeUploadBtn from '../ResumeUploadBtn'
-import { FormSpacing } from './index'
+import { FormSpacing, SubHeading } from './'
 import styled from 'styled-components'
 
 const QuestionForm = styled.form`
@@ -28,28 +28,34 @@ const FormRow = ({ id, children }) => (
   </div>
 )
 
+const StyledTextArea = styled(TextArea)`
+  margin: 1em 0;
+`
+
 export default ({ formInputs, onChange, role, handleResume }) => {
   return (
     <>
-      <CenteredH1>
-        Flex your skills!{' '}
-        <span role="img" aria-label="muscle">
-          &#128170;
-        </span>
-      </CenteredH1>
+      <FormSpacing>
+        <CenteredH1>
+          Flex your skills!{' '}
+          <span role="img" aria-label="muscle">
+            &#128170;
+          </span>
+        </CenteredH1>
+      </FormSpacing>
 
       <FormSpacing>
         <QuestionHeading>question 12</QuestionHeading>
-        <H1 size="1.5em">
+        <SubHeading>
           {' '}
           Don't be shy! Show off your wonderful skills{' '}
           <span role="img" aria-label="smiling face">
             &#128513;
           </span>
-        </H1>
-        <H2>
+        </SubHeading>
+        <H3>
           (Please ensure the links are publicly accessible by opening them in an incognito browser)
-        </H2>
+        </H3>
 
         <QuestionForm>
           <FormRow id="resume">
@@ -77,7 +83,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
                     portfolio: e.target.value,
                   })
                 }
-              ></TextInput>
+              />
             </FormRow>
           ) : (
             <FormRow id="github">
@@ -90,7 +96,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
                     github: e.target.value,
                   })
                 }
-              ></TextInput>
+              />
             </FormRow>
           )}
 
@@ -104,7 +110,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
                   linkedin: e.target.value,
                 })
               }
-            ></TextInput>
+            />
           </FormRow>
 
           {role === 'designer' ? (
@@ -118,7 +124,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
                     github: e.target.value,
                   })
                 }
-              ></TextInput>
+              />
             </FormRow>
           ) : (
             <FormRow id="portfolio">
@@ -131,7 +137,7 @@ export default ({ formInputs, onChange, role, handleResume }) => {
                     portfolio: e.target.value,
                   })
                 }
-              ></TextInput>
+              />
             </FormRow>
           )}
         </QuestionForm>
@@ -139,24 +145,24 @@ export default ({ formInputs, onChange, role, handleResume }) => {
 
       <FormSpacing>
         <QuestionHeading>question 13</QuestionHeading>
-        <H1 color="" size="1.5em">
-          {' '}
-          Answer one of the two questions:{' '}
-        </H1>
-        <H1 size="1.5em">
+        <SubHeading color="primary">Answer one of the two questions:</SubHeading>
+        <SubHeading size="1.25em">
           1. Describe how you became interested in the world of technology and here you hope to go
           from here on out!
-        </H1>
-        <H1 size="1.5em">2. How would you like to challenge yourself during this hackathon?</H1>
-        <TextArea
+        </SubHeading>
+        <SubHeading size="1.25em">
+          2. How would you like to challenge yourself during this hackathon?
+        </SubHeading>
+        <StyledTextArea
           maxLength="650"
+          width="100%"
           value={formInputs.longAnswers}
           onChange={val =>
             onChange({
               longAnswers: val,
             })
           }
-        ></TextArea>
+        />
       </FormSpacing>
     </>
   )

--- a/src/components/ApplicationForm/Skills.js
+++ b/src/components/ApplicationForm/Skills.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { CenteredH1, H1, H3, QuestionHeading } from '../Typography'
+import { CenteredH1, H3, QuestionHeading } from '../Typography'
 import { TextInput, TextArea } from '../Input'
 import ResumeUploadBtn from '../ResumeUploadBtn'
 import { FormSpacing, SubHeading } from './'

--- a/src/components/ApplicationForm/index.js
+++ b/src/components/ApplicationForm/index.js
@@ -1,18 +1,26 @@
 import React from 'react'
 import styled from 'styled-components'
+import { H1 } from '../Typography'
 
 const Container = styled.div`
-  padding: 8vh 19vw;
+  padding: 8vh 23vw;
   ${p => p.theme.mediaQueries.xs} {
     padding: 5vh 6vw;
   }
 `
 
 export const FormSpacing = styled.div`
-  margin-bottom: 5em;
+  margin-bottom: 4em;
   ${p => p.theme.mediaQueries.xs} {
     margin-bottom: 2em;
   }
+`
+
+export const SubHeading = styled(H1)`
+  && {
+    ${p => p.color === 'primary' && `color: ${p.theme.colors.primary};`}
+  }
+  font-size: ${p => p.size || `1.5em`};
 `
 
 export default ({ children }) => {

--- a/src/components/Input/Dropdown.js
+++ b/src/components/Input/Dropdown.js
@@ -20,7 +20,7 @@ const sharedStyle = css`
     border-radius: 7px;
     box-shadow: none;
     max-width: ${p => (p.isSearchable ? dropdownWidth.searchable : dropdownWidth.normal)};
-    height: 48px;
+    height: 2.5em;
     border-color: ${p => (p.isValid ? p.theme.colors.default : p.theme.colors.warning)};
     padding-right: 17px;
     padding-left: 7px;

--- a/src/components/Input/TextInput.js
+++ b/src/components/Input/TextInput.js
@@ -15,7 +15,8 @@ const TextInputContainer = styled.div`
   ${p =>
     p.inline &&
     `display: inline-block;
-  margin-left: 0;`}
+  margin-left: 0;
+  margin-top: 0.5em;`}
   ${p => p.noOutline && `margin: 0;`}
 `
 

--- a/src/components/NavigationButtons.js
+++ b/src/components/NavigationButtons.js
@@ -42,7 +42,7 @@ export default ({
 }) => {
   return (
     <NavigationButtonsContainer>
-      {autosaveTime && <I>Answers have been autosaved at {autosaveTime}</I>}
+      {autosaveTime && <I>Answers have been autosaved on {autosaveTime}</I>}
       <ButtonContainer>
         <StyledButton color="secondary" width="flex" onClick={firstButtonOnClick}>
           {firstButtonText}

--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -41,7 +41,7 @@ export default () => {
         firstButtonOnClick={() => handleNavigation('/application/part-3')}
         secondButtonText="Submit"
         secondButtonOnClick={() => handleNavigation('/application/confirmation')}
-        autosaveTime={application.submission.lastUpdated.toDate().toString()} // TODO: replace with application.submission.lastUpdated.toDate().toString()
+        autosaveTime={application.submission.lastUpdated.toDate().toString()}
       />
     </>
   )

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -9,7 +9,7 @@ export const NOTIFICATION_SETTINGS_CACHE_KEY = 'livesiteNotificationSettings'
 export const IS_DEVICE_IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
 export const copyText = Object.freeze({
   // CHANGE: name of hackathon to be displayed on login splash
-  hackathonName: 'HackCamp 2020',
+  hackathonName: 'nwHacks 2021',
 })
 
 export const NOTIFICATION_PERMISSIONS = Object.freeze({

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -2,7 +2,7 @@ import React from 'react'
 export const DB_COLLECTION = 'Hackathons'
 
 // CHANGE: firebase collection name for this hackathon
-export const DB_HACKATHON = 'LHD2021'
+export const DB_HACKATHON = 'nwHacks2021'
 
 export const FAQ_COLLECTION = 'FAQ'
 export const NOTIFICATION_SETTINGS_CACHE_KEY = 'livesiteNotificationSettings'


### PR DESCRIPTION
### Db and hackathon name
- Changed hackathon name to nwHacks; also changed db to `nwHacks2021`
- From now on, applicant objects will be created in `nwHacks2021` - in the `Applicants` collection

### UI changes
- Refactored usage of `H1` question subheading component 
- Made the spacing of input components look more consistent 

#### Before
<img width="713" alt="Screen Shot 2020-12-11 at 7 45 30 PM" src="https://user-images.githubusercontent.com/38872354/101973304-f3e29c00-3beb-11eb-84bc-8bb241198ecf.png">

#### After
<img width="611" alt="Screen Shot 2020-12-11 at 8 00 23 PM" src="https://user-images.githubusercontent.com/38872354/101973307-f8a75000-3beb-11eb-9e66-6c937392161e.png">


### Note regarding previous bug from #214 
- I couldn't reproduce the below issue @anneguo3 found, but I just decided to add an object validation check for `formInputs` before calling `Object.entries(formInputs...`
<img width="816" alt="Screen Shot 2020-12-10 at 8 39 06 PM" src="https://user-images.githubusercontent.com/38872354/101971826-0c04ec00-3be9-11eb-8e53-440aa3c2d1e2.png">
