### PR TITLE
Fixed dashboard messages

### DIFF
--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { H1 } from './Typography'
 import { Button } from './Input/Button'
-import { SOCIAL_LINKS, hackerStatuses } from '../utility/Constants'
+import { SOCIAL_LINKS, relevantDates, copyText } from '../utility/Constants'
 import facebook from '../assets/icons/facebook.svg'
 import instagram from '../assets/icons/instagram.svg'
 import medium from '../assets/icons/medium.svg'
@@ -111,6 +111,45 @@ const RSVPButton = styled(Button)`
   ${p => !p.shouldDisplay && 'display: none'}
 `
 
+export const hackerStatuses = (hackerFirstName = null) => ({
+  applied: {
+    sidebarText: 'In Review',
+    cardText: 'Awaiting assessment',
+    blurb: `We will send out all acceptances by ${relevantDates.sendAcceptancesBy}. In the mean time, get connected with our community of hackers on Medium, Twitter, and Facebook to stay up to date with the latest news on sponsors, prizes and workshops.`,
+  },
+  waitlisted: {
+    sidebarText: 'Waitlisted',
+    cardText: 'Waitlisted',
+    blurb: `Hi ${hackerFirstName}, we had a lovely time reading your application, and were very impressed with your commitment to joining the technology community. We would love to see you at ${copyText.hackathonName} this year, however, at the moment, we can not confirm a spot for you. You have been put in our waitlist, and will be notified by ${relevantDates.rsvpBy} if we found a spot for you, so please check your email then!`,
+  },
+  rejected: {
+    sidebarText: 'Rejected',
+    cardText: 'Rejected',
+    blurb: `Hi ${hackerFirstName}, we are sorry to inform you that we won't be able to give you a spot at ${copyText.hackathonName}. We had a lot of amazing applicants this year, and we are very grateful to have gotten yours, but we can't take everyone. We do hope to see your application next year and that this setback isn't the end of your tech career. Please visit our site nwplus.io to learn about more events and other ways to engage with the technology community.`,
+  },
+  acceptedNoResponseYet: {
+    sidebarText: 'Accepted, Awaiting RSVP',
+    cardText: 'Accepted & Awaiting RSVP',
+    blurb: `Congratulations! We loved the passion and drive we saw in your application, and we'd love even more for you to join us at ${copyText.hackathonName} over the weekend of ${relevantDates.hackathonDate}! RSVP before ${relevantDates.rsvpBy} to confirm your spot.`,
+  },
+  acceptedAndAttending: {
+    cardText: (
+      <>
+        Accepted &amp; RSVP'd{' '}
+        <span role="img" aria-label="celebrate emoji">
+          🎊
+        </span>
+      </>
+    ),
+    blurb: `We can't wait to see you at ${copyText.hackathonName}! You'll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can't make it to ${copyText.hackathonName} anymore due to change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers!`,
+  },
+  acceptedNotAttending: {
+    sidebarText: "Un-RSVP'd",
+    cardText: "Un-RSVP'd",
+    blurb: `We're sorry you won't be attending ${copyText.hackathonName}. We do hope to see you at our future events, visit our site nwplus.io or follow us on social media to learn about our events and other ways to engage with the technology community!`,
+  },
+})
+
 const SocialMediaLinks = () => {
   // TODO: Color of icons for HackCamp TBD
   return (
@@ -159,9 +198,9 @@ const Dashboard = ({
       <StatusContainer>
         <div>
           <AppStatusText>
-            Application status: {hackerStatuses[hackerStatus]['cardText']}
+            Application status: {hackerStatuses(username)[hackerStatus]['cardText']}
           </AppStatusText>
-          <StatusBlurbText>{hackerStatuses[hackerStatus]['blurb']}</StatusBlurbText>
+          <StatusBlurbText>{hackerStatuses(username)[hackerStatus]['blurb']}</StatusBlurbText>
         </div>
         <FooterContainer>
           <SocialMediaLinks />

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -6,7 +6,7 @@ import logo from '../assets/logo.svg'
 import hc_logo from '../assets/hc_logo.svg'
 import { Button } from './Input/index'
 import { useAuth } from '../utility/Auth'
-import { hackerStatuses } from '../utility/Constants'
+import { hackerStatuses } from './ApplicationDashboard'
 
 const SidebarContainer = styled.div`
   min-width: 275px;
@@ -145,7 +145,7 @@ export default ({
           <Link href={'/application'}>
             <StyledA selected={location === '/application'}>
               <ApplicationText>APPLICATION</ApplicationText>
-              <StatusText>{hackerStatuses[hackerStatus]['sidebarText']}</StatusText>
+              <StatusText>{hackerStatuses()[hackerStatus]['sidebarText']}</StatusText>
             </StyledA>
           </Link>
         )}

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -100,7 +100,7 @@ export const hackerApplicationTemplate = Object.freeze({
 
 // relevant dates for each status message displayed on the dashboard
 export const relevantDates = Object.freeze({
-  sendAcceptancesBy: 'December 20th, 2020',
+  sendAcceptancesBy: 'December 30th, 2020',
   rsvpBy: 'Janurary 7th at 11:59 PM (Pacific Time)',
   hackathonDate: 'January 9-10th',
 })

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -99,47 +99,9 @@ export const hackerApplicationTemplate = Object.freeze({
   team: '',
 })
 
-export const hackerStatuses = {
-  applied: {
-    sidebarText: 'In Review',
-    cardText: 'Awaiting assessment',
-    blurb:
-      'We will send out all acceptances by XX, XX, XXXX. In the mean time, get connected with our community of hackers on Medium, Twitter, and Facebook to stay up to date with the latest news on sponsors, prizes and workshops.',
-  },
-  waitlisted: {
-    sidebarText: 'Waitlisted',
-    cardText: 'Waitlisted',
-    blurb:
-      'Hi Haku, we had a lovely time reading your application, and  were very impressed with your commitment to joining the technology community. We would love to see you at nwHacks this year, however, at the moment, we can not confirm a spot for you. You have been put in our waitlist, and will be notified within ___ if we found a spot for you, so please check your email then!',
-  },
-  rejected: {
-    sidebarText: 'Rejected',
-    cardText: 'Rejected',
-    blurb:
-      "Hi Haku, we are sorry to inform you that we won't be able to give you a spot at nwHacks 2021. We had a lot of amazing applicants this year, and we are very grateful to have gotten yours, but we can't take everyone. We do hope to see your application next year and that this setback isn't the end of your tech career. Please visit our site nwplus.io to learn about more events and other ways to engage with the technology community.",
-  },
-  acceptedNoResponseYet: {
-    sidebarText: 'Accepted, Awaiting RSVP',
-    cardText: 'Accepted & Awaiting RSVP',
-    blurb:
-      "Congratulations! We loved the passion and drive we saw in your application, and we'd love even more for you to join us at nwHacks 2021 over the weekend of January XX-XX! RSVP before January Xth at 11:59 PM to confirm your spot.",
-  },
-  acceptedAndAttending: {
-    cardText: (
-      <>
-        Accepted &amp; RSVP'd{' '}
-        <span role="img" aria-label="celebrate emoji">
-          🎊
-        </span>
-      </>
-    ),
-    blurb:
-      "We can't wait to see you at nwHacks! You'll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can't make it to nwHacks anymore due to change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers!",
-  },
-  acceptedNotAttending: {
-    sidebarText: "Un-RSVP'd",
-    cardText: "Un-RSVP'd",
-    blurb:
-      "We're sorry you won't be attending nwHacks this year. We do hope to see you at our future events, visit our site nwplus.io or follow us on social media to learn about our events and other ways to engage with the technology community!",
-  },
-}
+// relevant dates for each status message displayed on the dashboard
+export const relevantDates = Object.freeze({
+  sendAcceptancesBy: 'December 20th, 2020',
+  rsvpBy: 'Janurary 7th at 11:59 PM (Pacific Time)',
+  hackathonDate: 'January 9-10th',
+})

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -1,4 +1,3 @@
-import React from 'react'
 export const DB_COLLECTION = 'Hackathons'
 
 // CHANGE: firebase collection name for this hackathon


### PR DESCRIPTION
- Tweaked dashboard messages to use date constants for relevant dates, e.g. `We will send out all acceptances by ${relevantDates.sendAcceptancesBy}....` 
- Reference applicant's name instead of using hard-coded name