### PR TITLE
Changed date fields used for dashboard to use constants for now instead of firebase

### DIFF
--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -3,30 +3,33 @@ import Dashboard from '../../components/ApplicationDashboard'
 import { useHackerApplication } from '../../utility/HackerApplicationContext'
 import { useAuth } from '../../utility/Auth'
 import { useLocation } from 'wouter'
-import { livesiteDocRef, getLivesiteDoc } from '../../utility/firebase'
+import { relevantDates } from '../../utility/Constants'
+import { getLivesiteDoc } from '../../utility/firebase'
 import Page from '../../components/Page'
 
 const ApplicationDashboardContainer = () => {
   const { application, updateApplication, forceSave } = useHackerApplication()
   const [livesiteDoc, setLivesiteDoc] = useState(false)
-  const [relevantDates, setRelevantDates] = useState({})
+  // const [relevantDates, setRelevantDates] = useState({})
   const { user } = useAuth()
   const [, setLocation] = useLocation()
 
-  useEffect(() => {
-    const unsubscribe = livesiteDocRef.onSnapshot(doc => {
-      const d = doc.data()
-      if (d) {
-        setRelevantDates({
-          sendAcceptancesBy: d.sendAcceptancesBy,
-          rsvpBy: d.rsvpBy,
-          offWaitlistNotify: d.offWaitlistNotify,
-          hackathonWeekend: d.hackathonWeekend,
-        })
-      }
-    })
-    return unsubscribe
-  }, [setRelevantDates])
+  // commenting this out until we add support in the cms for setting these fields
+
+  // useEffect(() => {
+  //   const unsubscribe = livesiteDocRef.onSnapshot(doc => {
+  //     const d = doc.data()
+  //     if (d) {
+  //       setRelevantDates({
+  //         sendAcceptancesBy: d.sendAcceptancesBy,
+  //         rsvpBy: d.rsvpBy,
+  //         offWaitlistNotify: d.offWaitlistNotify,
+  //         hackathonWeekend: d.hackathonWeekend,
+  //       })
+  //     }
+  //   })
+  //   return unsubscribe
+  // }, [setRelevantDates])
 
   const hackerStatusObject = application.status
   const hackerStatus =

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -97,3 +97,11 @@ export const hackerApplicationTemplate = Object.freeze({
   },
   team: '',
 })
+
+// temporarily using constants until we add additional fields in the CMs
+export const relevantDates = Object.freeze({
+  rsvpBy: 'Janurary 3rd at 11:59 PM (Pacific Time)',
+  offWaitlistNotify: 'one week before the event',
+  sendAcceptancesBy: 'December 30th, 2020',
+  hackathonWeekend: 'January 9-10th',
+})


### PR DESCRIPTION
Since the prod db doesn't have support for the new livesite date fields, they're currently undefined 
Changing the applicant dashboard to use local constants for now (will uncomment when the fields are created)

In prod, dates are undefined
<img width="1101" alt="Screen Shot 2020-12-13 at 12 52 23 AM" src="https://user-images.githubusercontent.com/38872354/102007553-f4a82a80-3cde-11eb-8c0f-72dcb9713a4c.png">
