### PR TITLE
Removed location check for /application in Auth

### DIFF
--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -22,13 +22,12 @@ export default () => {
   }
 
   const handleSubmit = async href => {
-    await forceSave()
     updateApplication({
-      ...application,
       status: {
         applicationStatus: ApplicationStatus.applied,
       },
     })
+    await forceSave()
     setLocation(href)
     window.scrollTo(0, 0)
   }

--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import NavigationButtons from '../../components/NavigationButtons'
 import VerticalProgressBar from '../../components/VerticalProgressBar'
 import { useLocation } from 'wouter'
@@ -21,16 +21,20 @@ export default () => {
     window.scrollTo(0, 0)
   }
 
-  const handleSubmit = async href => {
+  const handleSubmit = async () => {
     updateApplication({
       status: {
         applicationStatus: ApplicationStatus.applied,
       },
     })
-    await forceSave()
-    setLocation(href)
-    window.scrollTo(0, 0)
   }
+
+  useEffect(() => {
+    if (application.applicationStatus === ApplicationStatus.applied) {
+      setLocation('/application/confirmation')
+      window.scrollTo(0, 0)
+    }
+  }, application)
 
   const updateTermsAndConditions = change => {
     updateApplication({
@@ -52,7 +56,7 @@ export default () => {
         firstButtonText="Back"
         firstButtonOnClick={() => handleNavigation('/application/part-3')}
         secondButtonText="Submit"
-        secondButtonOnClick={() => handleSubmit('/application/confirmation')}
+        secondButtonOnClick={() => handleSubmit()}
         autosaveTime={application.submission.lastUpdated.toDate().toString()}
       />
     </>

--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -30,11 +30,12 @@ export default () => {
   }
 
   useEffect(() => {
-    if (application.applicationStatus === ApplicationStatus.applied) {
+    console.log(application)
+    if (application.status.applicationStatus === ApplicationStatus.applied) {
       setLocation('/application/confirmation')
       window.scrollTo(0, 0)
     }
-  }, application)
+  })
 
   const updateTermsAndConditions = change => {
     updateApplication({

--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -30,7 +30,6 @@ export default () => {
   }
 
   useEffect(() => {
-    console.log(application)
     if (application.status.applicationStatus === ApplicationStatus.applied) {
       setLocation('/application/confirmation')
       window.scrollTo(0, 0)

--- a/src/utility/Auth.js
+++ b/src/utility/Auth.js
@@ -20,7 +20,7 @@ export const checkAdminClaim = async user => {
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
-  const [location, setLocation] = useLocation()
+  const [, setLocation] = useLocation()
 
   useEffect(() => {
     return firebase.auth().onAuthStateChanged(async currUser => {

--- a/src/utility/Auth.js
+++ b/src/utility/Auth.js
@@ -20,7 +20,7 @@ export const checkAdminClaim = async user => {
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
-  const [, setLocation] = useLocation()
+  const [location, setLocation] = useLocation()
 
   useEffect(() => {
     return firebase.auth().onAuthStateChanged(async currUser => {
@@ -34,6 +34,9 @@ export function AuthProvider({ children }) {
       const admin = await checkAdminClaim(currUser)
       currUser.admin = admin
       setUser(currUser)
+      if (location === '/application') {
+        await handleUser(setUser, setLocation)
+      }
       setLoading(false)
     })
   })

--- a/src/utility/Auth.js
+++ b/src/utility/Auth.js
@@ -34,9 +34,6 @@ export function AuthProvider({ children }) {
       const admin = await checkAdminClaim(currUser)
       currUser.admin = admin
       setUser(currUser)
-      if (location === '/application') {
-        await handleUser(setUser, setLocation)
-      }
       setLoading(false)
     })
   })

--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -85,7 +85,6 @@ export function HackerApplicationProvider({ children }) {
     skills,
     questionnaire,
     status,
-    submission,
     termsAndConditions,
     team,
   }) => {
@@ -106,10 +105,6 @@ export function HackerApplicationProvider({ children }) {
       status: {
         ...application.status,
         ...status,
-      },
-      submission: {
-        ...application.submission,
-        ...submission,
       },
       termsAndConditions: {
         ...application.termsAndConditions,


### PR DESCRIPTION
The location check previously added should already be handled in `getRedirectUrl`
```
if (location === '/application') {
        await handleUser(setUser, setLocation)
      }
```
`getRedirectUrl`
```
export const getRedirectUrl = redirect => {
  if (process.env.NODE_ENV === 'production' || process.env.REACT_APP_ENV === 'STAGING') {
    if (DB_HACKATHON === 'LHD2021') return '/submission'
  }
  switch (redirect) {
    case RedirectStatus.AttendingEvent && DB_HACKATHON === 'LHD2021':
      return '/submission'
    case RedirectStatus.ApplicationNotSubmitted:
      return '/application/part-1'
    case RedirectStatus.ApplicationSubmitted:
    default:
      return '/application'
  }
}
```