### PR TITLE
Handle ignorable firebase auth errors

### DIFF
--- a/src/components/ErrorBanner.js
+++ b/src/components/ErrorBanner.js
@@ -6,11 +6,12 @@ const ErrorDiv = styled.div`
   max-width: 400px;
   background-color: ${p => p.theme.colors.error};
   position: fixed;
-  bottom: ${p => (p.shown ? '10px' : '-100px')};
+  bottom: ${p => (p.shown ? '40px' : '-100px')};
   opacity: ${p => (p.shown ? '100%' : '0%')};
   transition: all 0.5s ease-in;
   margin-left: auto;
   margin-right: auto;
+  padding: 0.25em 0.5em 0.5em;
   left: 0;
   right: 0;
   border-radius: 5px;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -6,7 +6,7 @@ import { Button } from '../components/Input'
 import google from '../assets/icons/google.svg'
 import github from '../assets/icons/github.svg'
 import { useAuth, googleSignIn, githubSignIn } from '../utility/Auth'
-import { DB_HACKATHON } from '../utility/Constants'
+import { DB_HACKATHON, firebaseAuthError } from '../utility/Constants'
 import { useLocation } from 'wouter'
 import ErrorBanner from '../components/ErrorBanner'
 import { A } from '../components/Typography'
@@ -14,13 +14,28 @@ import { copyText } from '../utility/Constants'
 
 const ErrorMessage = ({ message }) => (
   <>
-    There was an issue logging you in. If this persists, please contact"
-    <A href="mailto:info@nwplus.io">info@nwplus.io</A>.
+    There was an issue logging you in{' '}
+    <span role="img" aria-label="dizzy face">
+      😵
+    </span>
     <br />
+    {message}
     <br />
-    Error: {message}
+    If this persists, please contact <A href="mailto:info@nwplus.io">info@nwplus.io</A>.
   </>
 )
+
+// custom handling of errors
+const handleAuthError = (code, message) => {
+  switch (code) {
+    case firebaseAuthError.EXPIRED_POPUP_REQUEST:
+      return null
+    case firebaseAuthError.POPUP_CLOSED_BY_USER:
+      return null
+    default:
+      return <ErrorMessage message={message} />
+  }
+}
 
 const BoundingBox = styled.img`
   margin: 0 0.75em;
@@ -86,7 +101,7 @@ export default () => {
         </ButtonContainer>
         {DB_HACKATHON === 'LHD2021' && <A href="/">Return to Portal</A>}
       </Landing>
-      <ErrorBanner>{error ? <ErrorMessage message={error.message} /> : null}</ErrorBanner>
+      <ErrorBanner>{error ? handleAuthError(error.code, error.message) : null}</ErrorBanner>
     </>
   )
 }

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -106,3 +106,9 @@ export const relevantDates = Object.freeze({
   sendAcceptancesBy: 'December 30th, 2020',
   hackathonWeekend: 'January 9-10th',
 })
+
+// firebase auth error codes that are currently custom-handled
+export const firebaseAuthError = {
+  EXPIRED_POPUP_REQUEST: 'auth/cancelled-popup-request',
+  POPUP_CLOSED_BY_USER: 'auth/popup-closed-by-user',
+}


### PR DESCRIPTION
### Ignoring certain errors
Added error-handling of `cancelled-popup-request` as observed by @dryu99 
Also added `user-cancelled` error to the ignore list, since this may get thrown as well when the user closes the popup

![image](https://user-images.githubusercontent.com/38872354/102173603-31dffa00-3e50-11eb-8105-c6a939225059.png)

### Slight change to `ErrorDiv`
<img width="722" alt="Screen Shot 2020-12-14 at 9 02 29 PM" src="https://user-images.githubusercontent.com/38872354/102174061-5dafaf80-3e51-11eb-8386-a2edf798606f.png">
