### PR TITLE
Some changes and fixes to resume uploading

### DIFF
--- a/src/components/ApplicationForm/ReviewCards.js
+++ b/src/components/ApplicationForm/ReviewCards.js
@@ -197,14 +197,7 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
         </JohnDiv>
         <StyledBanner wide={true} blur>
           <ContentWrapper>
-            <InfoGroup
-              heading="Resume"
-              data={
-                formInputs.skills.resume
-                  ? formInputs.skills.resume.match(/[/\\]([\w\d\s.\-()]+)$/)[1]
-                  : ''
-              }
-            />
+            <InfoGroup heading="Resume" data={formInputs.skills.resume ?? ''} />
             <InfoGroup heading="Portfolio" data={formInputs.skills.portfolio} />
             <InfoGroup heading="LinkedIn" data={formInputs.skills.linkedin} />
             <InfoGroup heading="GitHub" data={formInputs.skills.github} />

--- a/src/components/ApplicationForm/Skills.js
+++ b/src/components/ApplicationForm/Skills.js
@@ -65,9 +65,6 @@ export default ({ errors, formInputs, onChange, role, handleResume }) => {
             <ResumeUploadBtn
               onChange={e => {
                 if (e.target.files[0]) {
-                  onChange({
-                    resume: e.target.value,
-                  })
                   handleResume(e.target.files[0])
                 }
               }}

--- a/src/components/ResumeUploadBtn.js
+++ b/src/components/ResumeUploadBtn.js
@@ -30,14 +30,7 @@ export default ({ onChange, hint, errorMsg }) => {
     <ResumeContainer>
       <ResumeFile inputFile={inputFile} onChange={onChange} />
       <UploadButton handleClick={handleClick} />
-      {hint !== undefined &&
-        (hint ? (
-          hint.match(/[/\\]([\w\d\s.\-()]+)$/) != null && (
-            <span>{hint.match(/[/\\]([\w\d\s.\-()]+)$/)[1]}</span>
-          )
-        ) : (
-          <ErrorMessage>{errorMsg}</ErrorMessage>
-        ))}
+      {hint ? <span>{hint}</span> : <ErrorMessage>{errorMsg}</ErrorMessage>}
     </ResumeContainer>
   )
 }

--- a/src/components/ResumeUploadBtn.js
+++ b/src/components/ResumeUploadBtn.js
@@ -30,7 +30,7 @@ export default ({ onChange, hint, errorMsg }) => {
     <ResumeContainer>
       <ResumeFile inputFile={inputFile} onChange={onChange} />
       <UploadButton handleClick={handleClick} />
-      {hint ? <span>{hint}</span> : <ErrorMessage>{errorMsg}</ErrorMessage>}
+      {hint ? <span>✔ {hint} uploaded!</span> : <ErrorMessage>{errorMsg}</ErrorMessage>}
     </ResumeContainer>
   )
 }

--- a/src/containers/Application/Part2.js
+++ b/src/containers/Application/Part2.js
@@ -12,7 +12,6 @@ import {
 
 export default () => {
   const { application, updateApplication, forceSave } = useHackerApplication()
-  const [resume, setResume] = useState()
   const [, setLocation] = useLocation()
   const [errors, setErrors] = useState({})
 
@@ -31,23 +30,24 @@ export default () => {
     })
   }
 
-  const handleResume = resume => {
+  const handleResume = async resume => {
+    // check to make sure its a pdf
+    const newErrors = validate({
+      resume: resume.name,
+    })
+    // check to make sure its under 2mb
     const size = (resume.size / 1024 / 1024).toFixed(2)
-    if (size > MAX_RESUME_FILE_SIZE_MB) {
-      alert(`File must be less than ${MAX_RESUME_FILE_SIZE_MB} MB`)
-      updateApplication({
-        skills: {
-          resume: '',
-        },
-      })
-    } else {
-      setResume(resume)
-    }
+    if (size > MAX_RESUME_FILE_SIZE_MB || newErrors.resume) return
+
+    // upload the resume and update the application on success.
+    await uploadResumeToStorage(application._id, resume)
+    updateSkillsInfo({
+      resume: resume.name,
+    })
   }
 
   const handleNavigation = async href => {
     await forceSave()
-    await uploadResumeToStorage(application._id, resume)
     if (href === '/application/part-3') {
       const newErrors = validate(application.skills)
       if (checkForError(newErrors)) {


### PR DESCRIPTION
### Main changes
- The upload happens as soon as the user selects the resume.
- The resume name is now set after the upload completes.
- `handleResume` now handles validating the resume name and the file size before uploading.
- resume name is now taken from `file.name` rather than `e.target.value`, giving us names without weird prefixes. (e.g. `my-resume.pdf` vs `c:\fakedir\my-resume.pdf`)
- I added a message in the `ResumeUploadButton` hint that states the resume was successfully uploaded.

   <img width="512" alt="image" src="https://user-images.githubusercontent.com/26512016/102201450-fa3a7780-3e7a-11eb-953e-bc909ec075d6.png">

   **(Note, if an upload fails and a resume was previous uploaded, the name will stay and an error will also be shown. This is intended as the original resume is still uploaded.)**
### Fixes
- The review page was crashing because the regex string used to remove the prefix from the file name didn't like a `#` symbol in the file name.
- Now that we no longer have the file prefix, we no longer have the need for the match string, so I removed it.

This should fix the issues with the review page crashing as well as handle the file upload in a cleaner way.

### How to test
1. navigate to the preview URL.
2. Start filling out the application form.
3. On part two, try to upload these cases:
   A) A file over 2mb.
   B) A file under 2mb but not a pdf.
   C) A file that is a PDF under 2mb.
4. Make sure that you get errors if you try option A and option B.
	- The errors should be the same.
	- the name of the file you are uploading should not show up next to the upload button.
5. make sure that you get no errors when you try option C
6. make sure that the name of the file you uploaded when trying option C is shown next to the upload button (as soon in the screenshot above)
7. make sure that the name of the file you uploaded in option C shows up in the review oprtion of the application under the skills section.