### PR TITLE
Responsive review page and logo lockup bug

### DIFF
--- a/src/components/ApplicationForm/ReviewCards.js
+++ b/src/components/ApplicationForm/ReviewCards.js
@@ -5,6 +5,7 @@ import Banner from '../Banner'
 import { H1, P, QuestionHeading, A, ErrorSpan as Required } from '../Typography'
 import { Button, Checkbox } from '../Input'
 import { CenterHorizontally } from '../Common'
+import { FormSpacing } from './'
 
 const HoloBackground = styled.img`
   position: absolute;
@@ -20,12 +21,18 @@ const HoloBackground = styled.img`
   left: 0;
   height: min-content;
   ${CenterHorizontally}
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    display: none;
+  }
 `
 
 const ReviewContainer = styled.div`
   position: relative;
   max-width: 100%;
   margin: 3em auto;
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    margin: 1em auto;
+  }
 `
 
 const ContentWrapper = styled.div`
@@ -36,6 +43,12 @@ grid-template-columns: auto auto;
 grid-template-rows: auto auto auto auto auto auto;
 grid-gap: 0;`}
   padding: ${p => (p.textBlock ? `0.5em 0` : `2em`)};
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    padding: 1em;
+  }
+  ${p => p.theme.mediaQueries.xs} {
+    padding: 1.5em;
+  }
 `
 
 const InfoGroupWrapper = styled.div`
@@ -43,8 +56,19 @@ const InfoGroupWrapper = styled.div`
 `
 
 const StyledH1 = styled(H1)`
-  color: ${p => p.theme.colors.primary};
+  color: ${p => (p.heading ? p.theme.colors.primary : p.theme.colors.text)};
   overflow-wrap: break-word;
+  font-size: ${p => (p.heading ? `1.2em` : `1.5em`)};
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    font-size: ${p => (p.heading ? `1em` : `1.1em`)};
+    margin-top: 0;
+    margin-bottom: 0.5em;
+  }
+  ${p => p.theme.mediaQueries.xs} {
+    margin-top: 0;
+    font-size: ${p => (p.heading ? `1em` : `1.2em`)};
+    margin-bottom: 0.5em;
+  }
 `
 
 const StyledBanner = styled(Banner)`
@@ -71,8 +95,8 @@ const CenterH1 = styled(H1)`
 
 const InfoGroup = ({ heading, data }) => (
   <InfoGroupWrapper>
-    <H1 size="1.2em">{heading}</H1>
-    <StyledH1 size="1.5em">{data}</StyledH1>
+    <StyledH1 heading>{heading}</StyledH1>
+    <StyledH1>{data}</StyledH1>
   </InfoGroupWrapper>
 )
 
@@ -131,12 +155,14 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
 
   return (
     <>
-      <CenterH1>
-        Review Your Application&nbsp;
-        <span role="img" aria-label="eyes">
-          &#128064;
-        </span>
-      </CenterH1>
+      <FormSpacing>
+        <CenterH1>
+          Review Your Application&nbsp;
+          <span role="img" aria-label="eyes">
+            &#128064;
+          </span>
+        </CenterH1>
+      </FormSpacing>
 
       <ReviewContainer>
         <JohnDiv>
@@ -260,6 +286,7 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
         </ContentWrapper>
         <ContentWrapper textBlock>
           <Checkbox
+            flex
             checked={formInputs.termsAndConditions.MLHCodeOfConduct}
             onChange={() =>
               onChange({
@@ -268,16 +295,18 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
             }
             required
           >
-            I have read and agree to the{' '}
-            <A
-              bolded
-              color="primary"
-              href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
-              target="_blank"
-            >
-              MLH Code of Conduct
-            </A>
-            .<Required />
+            <span>
+              I have read and agree to the{' '}
+              <A
+                bolded
+                color="primary"
+                href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"
+                target="_blank"
+              >
+                MLH Code of Conduct
+              </A>
+              .<Required />
+            </span>
           </Checkbox>
           <Checkbox
             flex
@@ -309,6 +338,7 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
             </span>
           </Checkbox>
           <Checkbox
+            flex
             checked={formInputs.termsAndConditions.shareWithnwPlus}
             onChange={() =>
               onChange({
@@ -317,8 +347,10 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
             }
             required
           >
-            I agree to allow my anonymized data to be used for nwPlus data reporting.
-            <Required />
+            <span>
+              I agree to allow my anonymized data to be used for nwPlus data reporting.
+              <Required />
+            </span>
           </Checkbox>
           <Checkbox
             flex
@@ -328,8 +360,10 @@ export default ({ formInputs, handleEdit, onChange, errors }) => {
                 shareWithSponsors: !formInputs.termsAndConditions.shareWithSponsors,
               })
             }
-            label="I would like to share my resume and supporting links (Linkedin, GitHub, Portfolio) to event sponsors and recruiters."
-          />
+          >
+            I would like to share my resume and supporting links (Linkedin, GitHub, Portfolio) to
+            event sponsors and recruiters.
+          </Checkbox>
         </ContentWrapper>
       </ReviewContainer>
       <HoloBackground src={holo} />

--- a/src/components/ApplicationForm/Skills.js
+++ b/src/components/ApplicationForm/Skills.js
@@ -15,6 +15,15 @@ const QuestionForm = styled.form`
       display: table-cell;
     }
   }
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    & > div {
+      display: block;
+      & > * {
+        display: block;
+        margin: 0.5em 0;
+      }
+    }
+  }
 `
 
 const QuestionRow = styled(QuestionHeading)`
@@ -76,6 +85,7 @@ export default ({ errors, formInputs, onChange, role, handleResume }) => {
           {role === 'designer' ? (
             <FormRow id="portfolio">
               <TextInput
+                inline
                 placeholder="Optional"
                 size="large"
                 value={formInputs.portfolio}
@@ -91,6 +101,7 @@ export default ({ errors, formInputs, onChange, role, handleResume }) => {
           ) : (
             <FormRow id="github">
               <TextInput
+                inline
                 placeholder="Optional"
                 size="large"
                 value={formInputs.github}
@@ -107,6 +118,7 @@ export default ({ errors, formInputs, onChange, role, handleResume }) => {
 
           <FormRow id="linkedin">
             <TextInput
+              inline
               placeholder="Optional"
               size="large"
               value={formInputs.linkedin}
@@ -123,6 +135,7 @@ export default ({ errors, formInputs, onChange, role, handleResume }) => {
           {role === 'designer' ? (
             <FormRow id="github">
               <TextInput
+                inline
                 placeholder="Optional"
                 size="large"
                 value={formInputs.github}
@@ -138,6 +151,7 @@ export default ({ errors, formInputs, onChange, role, handleResume }) => {
           ) : (
             <FormRow id="portfolio">
               <TextInput
+                inline
                 placeholder="Optional"
                 size="large"
                 value={formInputs.portfolio}

--- a/src/components/ApplicationForm/index.js
+++ b/src/components/ApplicationForm/index.js
@@ -4,6 +4,9 @@ import { H1 } from '../Typography'
 
 const Container = styled.div`
   padding: 8vh 23vw;
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    padding: 5vh 15vw;
+  }
   ${p => p.theme.mediaQueries.xs} {
     padding: 5vh 6vw;
   }
@@ -11,8 +14,11 @@ const Container = styled.div`
 
 export const FormSpacing = styled.div`
   margin-bottom: 4em;
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    margin-bottom: 2.5em;
+  }
   ${p => p.theme.mediaQueries.xs} {
-    margin-bottom: 2em;
+    margin-bottom: 1.5em;
   }
 `
 
@@ -21,6 +27,9 @@ export const SubHeading = styled(H1)`
     ${p => p.color === 'primary' && `color: ${p.theme.colors.primary};`}
   }
   font-size: ${p => p.size || `1.5em`};
+  ${p => p.theme.mediaQueries.tabletLarge} {
+    font-size: ${p => p.size || `1.2em`};
+  }
 `
 
 export default ({ children }) => {

--- a/src/components/ResumeUploadBtn.js
+++ b/src/components/ResumeUploadBtn.js
@@ -11,11 +11,15 @@ const ResumeFile = ({ inputFile, onChange }) => {
   return <input ref={inputFile} type="file" hidden onChange={onChange} />
 }
 
+const StyledButton = styled(Button)`
+  margin-left: 0;
+`
+
 const UploadButton = ({ handleClick }) => {
   return (
-    <Button color="tertiary" onClick={handleClick}>
+    <StyledButton color="tertiary" onClick={handleClick}>
       Upload
-    </Button>
+    </StyledButton>
   )
 }
 

--- a/src/containers/Landing/index.js
+++ b/src/containers/Landing/index.js
@@ -46,7 +46,7 @@ const StyledLogoLockup = styled.img`
   top: 7em;
   margin: 0 50.5%;
   transform: translateX(-50%);
-  z-index: 1;
+  z-index: 9999;
 
   ${p =>
     p.theme.name === 'hackCamp' &&


### PR DESCRIPTION
### Improvements to responsiveness
- made the review page more responsive, which used to be a mess #237 
- also made part 2 of the form not a table when on mobile/tablet
- also fixed logo lockup bug #235 

### Before (issa disaster 🤡 )
- review cards way too skinny on ipad
- terms and conditions not aligned properly
<p float="left">
<img width="300" alt="Screen Shot 2020-12-15 at 8 11 00 PM" src="https://user-images.githubusercontent.com/38872354/102304276-f0178800-3f11-11eb-8a8e-21a02bb7ffa9.png">
<img width="300" alt="Screen Shot 2020-12-15 at 8 11 05 PM" src="https://user-images.githubusercontent.com/38872354/102304278-f148b500-3f11-11eb-9561-f5a31b005180.png">
<img width="418" alt="Screen Shot 2020-12-15 at 8 15 30 PM" src="https://user-images.githubusercontent.com/38872354/102304450-52708880-3f12-11eb-97a8-24271174f6ce.png">
</p>

### After
- much more room for the review cards on ipad/tablet
- text doesnt spill out on mobile
- terms and conditions - much more organized
<p float="left">
<img width="400" alt="Screen Shot 2020-12-15 at 8 06 32 PM" src="https://user-images.githubusercontent.com/38872354/102303999-4637fb80-3f11-11eb-8a3f-f949dfaa6e0f.png">
<img width="400" alt="Screen Shot 2020-12-15 at 8 06 36 PM" src="https://user-images.githubusercontent.com/38872354/102304003-47692880-3f11-11eb-850c-b5b0b9d8e09d.png">
<img width="250" alt="Screen Shot 2020-12-15 at 8 06 50 PM" src="https://user-images.githubusercontent.com/38872354/102304004-489a5580-3f11-11eb-9d4c-b59994f48ce9.png">
<img width="224" alt="Screen Shot 2020-12-15 at 8 06 57 PM" src="https://user-images.githubusercontent.com/38872354/102304006-4932ec00-3f11-11eb-884d-d8e5b365596f.png">
<img width="223" alt="Screen Shot 2020-12-15 at 8 07 12 PM" src="https://user-images.githubusercontent.com/38872354/102304009-49cb8280-3f11-11eb-915f-05bcc7fb991b.png">
</p>

### Note
I removed the background image on mobile, because I couldn't figure out how to cut off the horizontal overflow of the image. It also did some weird things to the % viewport of the screen (?) so I didn't want to risk unexpected behaviours

This wouldve looked nice but too bad the image overflowed :'(
```
${p => p.theme.mediaQueries.tabletLarge} {
    width: 180%;
  }
  ${p => p.theme.mediaQueries.xs} {
    width: 390%;
    left: 5vw;
  }
```
If anyone knows how to fix this lmk! (Tried `overflow-x: hidden` and searched around but couldn't figure it out)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/38872354/102304081-72537c80-3f11-11eb-9189-2b53aa245090.gif)

#### what it would've looked like if overflow-x was hidden
<p float="left">
<img width="300" alt="Screen Shot 2020-12-15 at 7 34 55 PM" src="https://user-images.githubusercontent.com/38872354/102305072-ee4ec400-3f13-11eb-9198-cafe3a427296.png">
<img width="408" alt="Screen Shot 2020-12-15 at 7 31 40 PM" src="https://user-images.githubusercontent.com/38872354/102305069-ebec6a00-3f13-11eb-9e22-5e2cfaa84aa0.png">
</p>

### To test
- please try going to part 2 of the form and the review page using the staging link on your phone/tablet
- to confirm that #235 is fixed, follow steps to reproduce and see if the bug shows up 🤡 