### PR TITLE
Fixed error with fields being set in incorrect places

### DIFF
--- a/src/utility/firebase.js
+++ b/src/utility/firebase.js
@@ -108,7 +108,10 @@ const createNewApplication = async user => {
 
   const newApplication = {
     ...HACKER_APPLICATION_TEMPLATE,
-    ...basicInfo,
+    basicInfo: {
+      ...HACKER_APPLICATION_TEMPLATE.basicInfo,
+      ...basicInfo,
+    },
     ...submission,
     ...userId,
     ...judging,


### PR DESCRIPTION
To address the bug with people not being able to proceed from part 1
<img width="981" alt="Screen Shot 2020-12-16 at 1 08 17 PM" src="https://user-images.githubusercontent.com/38872354/102406666-c5741080-3f9f-11eb-9f00-3625ad285a45.png">
<img width="778" alt="Screen Shot 2020-12-16 at 1 08 26 PM" src="https://user-images.githubusercontent.com/38872354/102406679-ca38c480-3f9f-11eb-94b6-e84eedaf7f15.png">

### Testing instructions
- delete your document from the staging db
- try logging in using the staging link
- fill out all of the fields and press next

### Note on recovering from this error
- manually delete their `firstName`, `lastName`, and `email` fields outside of the `basicInfo` map in the db
<img width="613" alt="Screen Shot 2020-12-16 at 1 10 24 PM" src="https://user-images.githubusercontent.com/38872354/102406877-12f07d80-3fa0-11eb-9729-9ed227a53e42.png">
