### PR TITLE
fix sponsor tier name check bug

### DIFF
--- a/src/components/SponsorLogos.js
+++ b/src/components/SponsorLogos.js
@@ -33,7 +33,8 @@ const tierRanks = {
 
 export default ({ sponsors }) => {
   const tiers = sponsors.reduce((accumulator, sponsor) => {
-    accumulator[sponsor.tier] = [...(accumulator[sponsor.tier] || []), sponsor]
+    const tierLowerCase = sponsor.tier.toLowerCase()
+    accumulator[tierLowerCase] = [...(accumulator[tierLowerCase] || []), sponsor]
     return accumulator // group by tier
   }, {})
 
@@ -47,7 +48,7 @@ export default ({ sponsors }) => {
   }
 
   const singleSponsor = (entry, i) => {
-    const imgWidth = maxSponsorWidth * (1 - 0.1 * tierRanks[entry.tier])
+    const imgWidth = maxSponsorWidth * (1 - 0.1 * tierRanks[entry.tier.toLowerCase()])
     return (
       <SponsorContainer key={i}>
         <a href={entry.link}>

--- a/src/containers/SponsorLogos.js
+++ b/src/containers/SponsorLogos.js
@@ -1,12 +1,24 @@
 import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { getSponsors } from '../utility/firebase'
 import Sponsors from '../components/SponsorLogos'
+import { db } from '../utility/firebase'
+import { DB_COLLECTION, DB_HACKATHON } from '../utility/Constants'
 
 const CenteredH2 = styled.h2`
   text-align: center;
   margin-bottom: 1em;
 `
+
+const getSponsors = () => {
+  return db
+    .collection(DB_COLLECTION)
+    .doc(DB_HACKATHON)
+    .collection('Sponsors')
+    .get()
+    .then(querySnapshot => {
+      return querySnapshot.docs
+    })
+}
 
 export default () => {
   const [sponsors, setSponsors] = useState([])
@@ -14,7 +26,9 @@ export default () => {
   useEffect(() => {
     getSponsors().then(docs => {
       // only keep non-inkind sponsors
-      const filteredDocs = docs.filter(doc => doc.data().tier !== 'inkind')
+      const filteredDocs = docs.filter(
+        doc => doc.data().tier && doc.data().tier.toLowerCase() !== 'inkind'
+      )
       setSponsors(filteredDocs.map(doc => doc.data()))
     })
   }, [setSponsors])

--- a/src/utility/firebase.js
+++ b/src/utility/firebase.js
@@ -41,17 +41,6 @@ export const getLivesiteDoc = callback => {
   })
 }
 
-export const getSponsors = () => {
-  return db
-    .collection(DB_COLLECTION)
-    .doc(DB_HACKATHON)
-    .collection('Sponsors')
-    .get()
-    .then(querySnapshot => {
-      return querySnapshot.docs
-    })
-}
-
 export const syncToFirebase = async (projects, setMessageCallback) => {
   // delete old projects
   setMessageCallback(`Snapping old projects...`)


### PR DESCRIPTION
Fixed bug where inkind sponsor logos were appearing on sponsors logo page (this shouldn't be happening). Bug was occurring because of tier name inconsistencies. We are now casting tier names to lowercase before running through relevant logic (e.g. Inkind vs inkind). 

Also moved `getSponsors` from firebase utils file to sponsors logo component to improve cohesion (I should've done this before 🙉 ) 