### PR TITLE
Uncommented firebase calls to grab dates from db and removed constants

### DIFF
--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -3,34 +3,31 @@ import Dashboard from '../../components/ApplicationDashboard'
 import { useHackerApplication } from '../../utility/HackerApplicationContext'
 import { useAuth } from '../../utility/Auth'
 import { useLocation } from 'wouter'
-import { relevantDates } from '../../utility/Constants'
-import { getLivesiteDoc } from '../../utility/firebase'
+import { getLivesiteDoc, livesiteDocRef } from '../../utility/firebase'
 import Page from '../../components/Page'
 
 const ApplicationDashboardContainer = () => {
   const { application, updateApplication, forceSave } = useHackerApplication()
   const [livesiteDoc, setLivesiteDoc] = useState(false)
-  // const [relevantDates, setRelevantDates] = useState({})
+  const [relevantDates, setRelevantDates] = useState({})
   const { user } = useAuth()
   const [, setLocation] = useLocation()
 
-  // commenting this out until we add support in the cms for setting these fields
-
-  // useEffect(() => {
-  //   const unsubscribe = livesiteDocRef.onSnapshot(doc => {
-  //     const d = doc.data()
-  //     if (d) {
-  //       setRelevantDates({
-  //         applicationDeadline: d.applicationDeadline,
-  //         sendAcceptancesBy: d.sendAcceptancesBy,
-  //         rsvpBy: d.rsvpBy,
-  //         offWaitlistNotify: d.offWaitlistNotify,
-  //         hackathonWeekend: d.hackathonWeekend,
-  //       })
-  //     }
-  //   })
-  //   return unsubscribe
-  // }, [setRelevantDates])
+  useEffect(() => {
+    const unsubscribe = livesiteDocRef.onSnapshot(doc => {
+      const d = doc.data()
+      if (d) {
+        setRelevantDates({
+          applicationDeadline: d.applicationDeadline,
+          sendAcceptancesBy: d.sendAcceptancesBy,
+          rsvpBy: d.rsvpBy,
+          offWaitlistNotify: d.offWaitlistNotify,
+          hackathonWeekend: d.hackathonWeekend,
+        })
+      }
+    })
+    return unsubscribe
+  }, [setRelevantDates])
 
   const hackerStatusObject = application.status
   const hackerStatus =

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -107,14 +107,6 @@ export const ANALYTICS_EVENTS = Object.freeze({
   Logout: 'Logout',
   NotificationToggled: 'NotificationToggled',
 })
-// temporarily using constants until we add additional fields in the CMs
-export const relevantDates = Object.freeze({
-  applicationDeadline: 'December 27th at 11:59PM (Pacific Time)',
-  rsvpBy: 'Janurary 3rd at 11:59PM (Pacific Time)',
-  offWaitlistNotify: 'one week before the event',
-  sendAcceptancesBy: 'December 30th, 2020',
-  hackathonWeekend: 'January 9-10th',
-})
 
 // firebase auth error codes that are currently custom-handled
 export const FIREBASE_AUTH_ERROR = {


### PR DESCRIPTION
## What was changed
- removed hard-coded constants for relevant dates
- uncommented out firebase calls

## Testing instructions
1. login to your account on the PR preview link
2. go to `/application`
3. make sure the dates dont say 'undefined'
<img width="955" alt="Screen Shot 2020-12-27 at 11 34 04 PM" src="https://user-images.githubusercontent.com/38872354/103197993-03c0d800-489c-11eb-861f-4eb6cfaac7e2.png">
4. go to staging db, change status to `waitlisted`, `accepted`, and repeat step 3

## Dependencies
https://github.com/nwplus/CMS-V2/pull/68 needs to be merge first