### PR TITLE
Fix blank dashboard when application status is 'scored'

### DIFF
--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -5,6 +5,7 @@ import { useAuth } from '../../utility/Auth'
 import { useLocation } from 'wouter'
 import { getLivesiteDoc, livesiteDocRef } from '../../utility/firebase'
 import Page from '../../components/Page'
+import { APPLICATION_STATUS } from '../../utility/Constants'
 
 const ApplicationDashboardContainer = () => {
   const { application, updateApplication, forceSave } = useHackerApplication()
@@ -30,7 +31,7 @@ const ApplicationDashboardContainer = () => {
   }, [setRelevantDates])
 
   const hackerStatusObject = application.status
-  const hackerStatus =
+  let hackerStatus =
     hackerStatusObject !== undefined &&
     (hackerStatusObject.applicationStatus === 'accepted'
       ? hackerStatusObject.responded
@@ -39,6 +40,10 @@ const ApplicationDashboardContainer = () => {
           : 'acceptedNotAttending'
         : 'acceptedNoResponseYet'
       : hackerStatusObject.applicationStatus)
+
+  // handle case where applicationStatus: scored
+  hackerStatus =
+    hackerStatus === APPLICATION_STATUS.scored ? APPLICATION_STATUS.applied : hackerStatus
 
   const canRSVP =
     hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'

--- a/src/utility/Constants.js
+++ b/src/utility/Constants.js
@@ -38,6 +38,7 @@ export const APPLICATION_STATUS = Object.freeze({
   rejected: 'rejected',
   waitlisted: 'waitlisted',
   inProgress: 'inProgress',
+  scored: 'scored',
 })
 
 export const HACKER_APPLICATION_TEMPLATE = Object.freeze({


### PR DESCRIPTION
## What was changed
- handle case where `applicationStatus: scored` due to the object being overwritten in the assessment portal
- the `scored` case essentially looks the same as `applied` to the user

## Testing instructions
1. login to hacker app and go to `/application`
2. go to the staging db and change your `applicationStatus` in the `status` object to `scored`
3. refresh the dashboard and you should see the view associated with the `applicationStatus: applied` case
4. change your `applicationStatus` to `applied` and refresh - the dashboard should look the same
<img width="1588" alt="Screen Shot 2020-12-29 at 10 38 30 AM" src="https://user-images.githubusercontent.com/38872354/103306377-411f8580-49c2-11eb-8242-239427c32e31.png">
<img width="580" alt="Screen Shot 2020-12-29 at 10 38 38 AM" src="https://user-images.githubusercontent.com/38872354/103306378-42e94900-49c2-11eb-8afc-aa75da4a6e8e.png">