### PR TITLE
Use rsvp flag

### DIFF
--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -209,6 +209,8 @@ const Dashboard = ({
   username,
   editApplication,
   relevantDates,
+  isRsvpOpen,
+  isLoadingAppStatus,
 }) => {
   return (
     <Container>
@@ -230,7 +232,14 @@ const Dashboard = ({
       <StatusContainer>
         <div>
           <AppStatusText>
-            Application status: {hackerStatuses(relevantDates, username)[hackerStatus]?.cardText}
+            Application status:{' '}
+            {hackerStatus === 'acceptedNoResponseYet'
+              ? !isLoadingAppStatus
+                ? isRsvpOpen
+                  ? hackerStatuses()[hackerStatus]?.cardText
+                  : 'NO RSVP'
+                : null
+              : hackerStatuses()[hackerStatus]?.cardText}
           </AppStatusText>
           <StatusBlurbText>
             {hackerStatuses(relevantDates, username)[hackerStatus]?.blurb}
@@ -240,10 +249,10 @@ const Dashboard = ({
           <SocialMediaLinks />
           <RSVPButton
             width="flex"
-            onClick={isApplicationOpen && (() => setRSVP(canRSVP))}
+            onClick={isRsvpOpen && (() => setRSVP(canRSVP))}
             shouldDisplay={canRSVP || hackerStatus === 'acceptedAndAttending'}
             color={canRSVP ? 'primary' : 'secondary'}
-            disabled={!isApplicationOpen}
+            disabled={!isRsvpOpen}
           >
             {canRSVP ? 'RSVP' : 'un-RSVP'}
           </RSVPButton>

--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -156,9 +156,24 @@ export const hackerStatuses = (relevantDates, hackerName = null) => ({
     ),
     blurb: `We can't wait to see you at ${copyText.hackathonName}! You'll be receiving another email closer to the event date with more information regarding the schedule and other logistics. If you find out you can't make it to ${copyText.hackathonName} anymore due to a change in your schedule, please update your RSVP status so we can allocate spots for waitlisted hackers!`,
   },
-  acceptedNotAttending: {
+  acceptedUnRSVP: {
     sidebarText: "Un-RSVP'd",
     cardText: "Un-RSVP'd",
+    blurb: (
+      <>
+        We're sorry you won't be attending {copyText.hackathonName}. We do hope to see you at our
+        future events, visit our site{' '}
+        <A bolded color="primary" href={SOCIAL_LINKS.WEBSITE}>
+          nwplus.io
+        </A>{' '}
+        or follow us on social media to learn about our events and other ways to engage with the
+        technology community!
+      </>
+    ),
+  },
+  acceptedNoRSVP: {
+    sidebarText: 'No RSVP',
+    cardText: 'No RSVP',
     blurb: (
       <>
         We're sorry you won't be attending {copyText.hackathonName}. We do hope to see you at our
@@ -210,7 +225,6 @@ const Dashboard = ({
   editApplication,
   relevantDates,
   isRsvpOpen,
-  isLoadingAppStatus,
 }) => {
   return (
     <Container>
@@ -232,14 +246,7 @@ const Dashboard = ({
       <StatusContainer>
         <div>
           <AppStatusText>
-            Application status:{' '}
-            {hackerStatus === 'acceptedNoResponseYet'
-              ? !isLoadingAppStatus
-                ? isRsvpOpen
-                  ? hackerStatuses()[hackerStatus]?.cardText
-                  : 'NO RSVP'
-                : null
-              : hackerStatuses()[hackerStatus]?.cardText}
+            Application status: {hackerStatuses()[hackerStatus]?.cardText}
           </AppStatusText>
           <StatusBlurbText>
             {hackerStatuses(relevantDates, username)[hackerStatus]?.blurb}

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -24,7 +24,7 @@ const Content = styled.div`
   }
 `
 
-const Page = ({ hackerStatus, isRsvpOpen, isLoadingAppStatus, children }) => {
+const Page = ({ hackerStatus, children }) => {
   const [showMobileSidebar, setShowMobileSidebar] = useState(false)
   const [livesiteDoc, setLivesiteDoc] = useState(false)
 
@@ -41,8 +41,6 @@ const Page = ({ hackerStatus, isRsvpOpen, isLoadingAppStatus, children }) => {
         isApplicationOpen={livesiteDoc.applicationsOpen}
         showMobileSidebar={showMobileSidebar}
         hackerStatus={hackerStatus}
-        isRsvpOpen={isRsvpOpen}
-        isLoadingAppStatus={isLoadingAppStatus}
       />
       <RightContentContainer>
         <MobileMenuBar

--- a/src/components/Page.js
+++ b/src/components/Page.js
@@ -24,7 +24,7 @@ const Content = styled.div`
   }
 `
 
-const Page = ({ hackerStatus, children }) => {
+const Page = ({ hackerStatus, isRsvpOpen, isLoadingAppStatus, children }) => {
   const [showMobileSidebar, setShowMobileSidebar] = useState(false)
   const [livesiteDoc, setLivesiteDoc] = useState(false)
 
@@ -41,6 +41,8 @@ const Page = ({ hackerStatus, children }) => {
         isApplicationOpen={livesiteDoc.applicationsOpen}
         showMobileSidebar={showMobileSidebar}
         hackerStatus={hackerStatus}
+        isRsvpOpen={isRsvpOpen}
+        isLoadingAppStatus={isLoadingAppStatus}
       />
       <RightContentContainer>
         <MobileMenuBar

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -155,7 +155,6 @@ export default ({
                     : null
                   : hackerStatuses()[hackerStatus]?.sidebarText}
               </StatusText>
-              {/* {!isRsvpOpen && hackerStatus === 'acceptedNoResponseYet' ? (isLoadingAppStatus ? null : 'NO RSVP') : hackerStatuses()[hackerStatus]?.sidebarText} */}
             </StyledA>
           </Link>
         )}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -95,6 +95,8 @@ export default ({
   isSubmissionsOpen,
   isApplicationOpen,
   hackerStatus,
+  isRsvpOpen,
+  isLoadingAppStatus,
 }) => {
   const [location] = useLocation()
   const { isAuthed, logout } = useAuth()
@@ -141,11 +143,19 @@ export default ({
             )
           })
         ) : (
-          // Not sure if I should abstract this case to use links.map
           <Link href={'/application'}>
             <StyledA selected={location === '/application'}>
               <ApplicationText>APPLICATION</ApplicationText>
-              <StatusText>{hackerStatuses()[hackerStatus]?.sidebarText}</StatusText>
+              <StatusText>
+                {hackerStatus === 'acceptedNoResponseYet'
+                  ? !isLoadingAppStatus
+                    ? isRsvpOpen
+                      ? hackerStatuses()[hackerStatus]?.sidebarText
+                      : 'NO RSVP'
+                    : null
+                  : hackerStatuses()[hackerStatus]?.sidebarText}
+              </StatusText>
+              {/* {!isRsvpOpen && hackerStatus === 'acceptedNoResponseYet' ? (isLoadingAppStatus ? null : 'NO RSVP') : hackerStatuses()[hackerStatus]?.sidebarText} */}
             </StyledA>
           </Link>
         )}

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -95,8 +95,6 @@ export default ({
   isSubmissionsOpen,
   isApplicationOpen,
   hackerStatus,
-  isRsvpOpen,
-  isLoadingAppStatus,
 }) => {
   const [location] = useLocation()
   const { isAuthed, logout } = useAuth()
@@ -146,15 +144,7 @@ export default ({
           <Link href={'/application'}>
             <StyledA selected={location === '/application'}>
               <ApplicationText>APPLICATION</ApplicationText>
-              <StatusText>
-                {hackerStatus === 'acceptedNoResponseYet'
-                  ? !isLoadingAppStatus
-                    ? isRsvpOpen
-                      ? hackerStatuses()[hackerStatus]?.sidebarText
-                      : 'NO RSVP'
-                    : null
-                  : hackerStatuses()[hackerStatus]?.sidebarText}
-              </StatusText>
+              <StatusText>{hackerStatuses()[hackerStatus]?.sidebarText}</StatusText>
             </StyledA>
           </Link>
         )}

--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -3,15 +3,25 @@ import Dashboard from '../../components/ApplicationDashboard'
 import { useHackerApplication } from '../../utility/HackerApplicationContext'
 import { useAuth } from '../../utility/Auth'
 import { useLocation } from 'wouter'
-import { getLivesiteDoc, livesiteDocRef } from '../../utility/firebase'
+import { getLivesiteDoc, livesiteDocRef, currentHackathonRef } from '../../utility/firebase'
 import Page from '../../components/Page'
 
 const ApplicationDashboardContainer = () => {
   const { application, updateApplication, forceSave } = useHackerApplication()
   const [livesiteDoc, setLivesiteDoc] = useState(false)
   const [relevantDates, setRelevantDates] = useState({})
+  const [isRsvpOpen, setIsRsvpOpen] = useState(false)
+  const [isLoadingAppStatus, setIsLoadingAppStatus] = useState(true)
   const { user } = useAuth()
   const [, setLocation] = useLocation()
+
+  useEffect(() => {
+    const unsubscribe = currentHackathonRef.onSnapshot(doc => {
+      setIsRsvpOpen(doc.data().featureFlags.rsvpOpenFlag)
+      setIsLoadingAppStatus(false)
+    })
+    return unsubscribe
+  }, [setIsRsvpOpen])
 
   useEffect(() => {
     const unsubscribe = livesiteDocRef.onSnapshot(doc => {
@@ -42,11 +52,11 @@ const ApplicationDashboardContainer = () => {
 
   const canRSVP =
     hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'
-  const setRSVP = canRSVP => {
+  const setRSVP = rsvpStatus => {
     updateApplication({
       status: {
         responded: true,
-        attending: canRSVP,
+        attending: rsvpStatus,
       },
     })
     forceSave()
@@ -58,15 +68,21 @@ const ApplicationDashboardContainer = () => {
   }, [setLivesiteDoc])
 
   return (
-    <Page hackerStatus={hackerStatus}>
+    <Page
+      hackerStatus={hackerStatus}
+      isRsvpOpen={isRsvpOpen}
+      isLoadingAppStatus={isLoadingAppStatus}
+    >
       <Dashboard
         editApplication={() => setLocation('/application/part-1')}
         username={user.displayName}
         hackerStatus={hackerStatus}
         isApplicationOpen={livesiteDoc.applicationsOpen}
-        setRSVP={() => setRSVP(canRSVP)}
+        setRSVP={rsvpStatus => setRSVP(rsvpStatus)}
         canRSVP={canRSVP}
         relevantDates={relevantDates}
+        isRsvpOpen={isRsvpOpen}
+        isLoadingAppStatus={isLoadingAppStatus}
       />
     </Page>
   )

--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -61,7 +61,10 @@ const ApplicationDashboardContainer = () => {
     hackerStatus = applicationStatus
   }
 
-  const canRSVP = hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedUnRSVP'
+  const canRSVP =
+    hackerStatus === 'acceptedNoResponseYet' ||
+    hackerStatus === 'acceptedUnRSVP' ||
+    hackerStatus === 'acceptedNoRSVP'
   const setRSVP = rsvpStatus => {
     updateApplication({
       status: {

--- a/src/containers/Application/Dashboard.js
+++ b/src/containers/Application/Dashboard.js
@@ -5,7 +5,6 @@ import { useAuth } from '../../utility/Auth'
 import { useLocation } from 'wouter'
 import { getLivesiteDoc, livesiteDocRef, currentHackathonRef } from '../../utility/firebase'
 import Page from '../../components/Page'
-import { APPLICATION_STATUS } from '../../utility/Constants'
 
 const ApplicationDashboardContainer = () => {
   const { application, updateApplication, forceSave } = useHackerApplication()
@@ -41,7 +40,7 @@ const ApplicationDashboardContainer = () => {
   }, [setRelevantDates])
 
   const hackerStatusObject = application.status
-  let hackerStatus =
+  const hackerStatus =
     hackerStatusObject !== undefined &&
     (hackerStatusObject.applicationStatus === 'accepted'
       ? hackerStatusObject.responded
@@ -49,11 +48,9 @@ const ApplicationDashboardContainer = () => {
           ? 'acceptedAndAttending'
           : 'acceptedNotAttending'
         : 'acceptedNoResponseYet'
+      : hackerStatusObject.applicationStatus === 'scored'
+      ? 'applied'
       : hackerStatusObject.applicationStatus)
-
-  // handle case where applicationStatus: scored
-  hackerStatus =
-    hackerStatus === APPLICATION_STATUS.scored ? APPLICATION_STATUS.applied : hackerStatus
 
   const canRSVP =
     hackerStatus === 'acceptedNoResponseYet' || hackerStatus === 'acceptedNotAttending'

--- a/src/pages/Application/index.js
+++ b/src/pages/Application/index.js
@@ -2,6 +2,6 @@ import React from 'react'
 import Dashboard from '../../containers/Application/Dashboard'
 
 // applicant dashboard
-export default ({ hackerStatus }) => {
-  return <Dashboard hackerStatus={hackerStatus} />
+export default () => {
+  return <Dashboard />
 }

--- a/src/utility/firebase.js
+++ b/src/utility/firebase.js
@@ -32,6 +32,7 @@ export const storage = firebase.storage()
 export const analytics = firebase.analytics()
 
 export const livesiteDocRef = db.collection('InternalWebsites').doc('Livesite')
+export const currentHackathonRef = db.collection(DB_COLLECTION).doc(DB_HACKATHON)
 export const applicantsRef = db.collection(DB_COLLECTION).doc(DB_HACKATHON).collection('Applicants')
 export const projectsRef = db.collection(DB_COLLECTION).doc(DB_HACKATHON).collection('Projects')
 


### PR DESCRIPTION
This PR closes #240.

## What changed

1. The RSVP button's state now depends on the `rsvpOpenFlag` in the CMS. Devs can now use the CMS to enable/disable RSVP in the feature flag section of nwHacks2021.
2. If the `rsvpOpenFlag` is toggled off and the applicant was accepted but still has not responded, the sidebar and dashboard will display the application status `NO RSVP`.
3. Some nit changes

## How to test

For the first change:
1. Make sure your entry in the `Applicant` collection has a status of `applied`  
2. Go to the CMS and toggle the `rsvpOpenFlag`, you should see the RSVP button being enabled/disabled when the flag is active/inactive

For the second change: 
1. Make sure your entry has a status of `applied`, `responded: false` and `attending: false`
2. Toggle the `rsvpOpenFlag`, you should see `NO RSVP` on the dashboard and sidebar

For the third change (general case):
Try out all the possible applicant states just in case