### PR TITLE
Only set applicationStatus to applied if current status is inProgress

### DIFF
--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -41,14 +41,13 @@ export default () => {
       window.alert('Please agree to the required terms and conditions.')
       return
     }
-    updateApplication({
-      status: {
-        applicationStatus:
-          application.status.applicationStatus === APPLICATION_STATUS.inProgress
-            ? APPLICATION_STATUS.applied
-            : application.status.applicationStatus,
-      },
-    })
+    if (application.status.applicationStatus === APPLICATION_STATUS.inProgress) {
+      updateApplication({
+        status: {
+          applicationStatus: APPLICATION_STATUS.applied,
+        },
+      })
+    }
     await save()
     setLocation('/application/confirmation')
     window.scrollTo(0, 0)

--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -43,7 +43,10 @@ export default () => {
     }
     updateApplication({
       status: {
-        applicationStatus: APPLICATION_STATUS.applied,
+        applicationStatus:
+          application.status.applicationStatus === APPLICATION_STATUS.inProgress
+            ? APPLICATION_STATUS.applied
+            : application.status.applicationStatus,
       },
     })
     await save()


### PR DESCRIPTION
## What was changed
- changed submit function to only set `applicationStatus` to `applied` if the current status is `inProgress`

## How to test
#### making sure `inProgress` status is set to `applied` upon submission
- go to `/application/review` on portal
- set your application status to `inProgress` in the db
- submit your application
- check the db - status should update to `applied` and dashboard should say awaiting assessment
#### making sure statuses other than `inProgress` is not set to applied after submission
- set your status in the db to `accepted`
- go to `application/review` to submit again
- status should not change