### PR TITLE
Disable edit

### DIFF
--- a/src/components/ApplicationDashboard.js
+++ b/src/components/ApplicationDashboard.js
@@ -237,10 +237,14 @@ const Dashboard = ({
         <EditAppButton
           color="secondary"
           height="short"
-          onClick={isApplicationOpen && (() => editApplication())}
-          disabled={!isApplicationOpen}
+          onClick={
+            isApplicationOpen &&
+            hackerStatus === APPLICATION_STATUS.inProgress &&
+            (() => editApplication())
+          }
+          disabled={!(isApplicationOpen && hackerStatus === APPLICATION_STATUS.inProgress)}
         >
-          {hackerStatus !== APPLICATION_STATUS.inProgress ? 'Edit' : 'Complete'} Your Application
+          Complete Your Application
         </EditAppButton>
       </AppLinks>
       <StatusContainer>

--- a/src/components/NavigationButtons.js
+++ b/src/components/NavigationButtons.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Button } from './Input'
-import { I } from './Typography'
+import { I, P } from './Typography'
 import MoonLoader from 'react-spinners/MoonLoader'
 
 const StyledButton = styled(Button)`
@@ -34,6 +34,10 @@ const NavigationButtonsContainer = styled.div`
   text-align: right;
 `
 
+const StyledAsterisk = styled.span`
+  color: ${p => p.theme.colors.warning};
+`
+
 export default ({
   firstButtonText,
   firstButtonOnClick,
@@ -41,6 +45,7 @@ export default ({
   secondButtonOnClick,
   autosaveTime,
   loading = false,
+  showSubmitWarning,
 }) => {
   return (
     <NavigationButtonsContainer>
@@ -56,6 +61,12 @@ export default ({
           </StyledButton>
         </div>
       </ButtonContainer>
+      {showSubmitWarning && (
+        <P>
+          <StyledAsterisk>**</StyledAsterisk> Caution! You cannot edit your application after
+          submitting.
+        </P>
+      )}
     </NavigationButtonsContainer>
   )
 }

--- a/src/components/NavigationButtons.js
+++ b/src/components/NavigationButtons.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Button } from './Input'
-import { I, P } from './Typography'
+import { ErrorMessage, I } from './Typography'
 import MoonLoader from 'react-spinners/MoonLoader'
 
 const StyledButton = styled(Button)`
@@ -34,10 +34,6 @@ const NavigationButtonsContainer = styled.div`
   text-align: right;
 `
 
-const StyledAsterisk = styled.span`
-  color: ${p => p.theme.colors.warning};
-`
-
 export default ({
   firstButtonText,
   firstButtonOnClick,
@@ -50,6 +46,9 @@ export default ({
   return (
     <NavigationButtonsContainer>
       {autosaveTime && <I>Answers have been autosaved on {autosaveTime}</I>}
+      {showSubmitWarning && (
+        <ErrorMessage>Caution! You cannot edit your application after submitting.</ErrorMessage>
+      )}
       <ButtonContainer>
         <StyledButton color="secondary" width="flex" onClick={firstButtonOnClick}>
           {firstButtonText}
@@ -61,12 +60,6 @@ export default ({
           </StyledButton>
         </div>
       </ButtonContainer>
-      {showSubmitWarning && (
-        <P>
-          <StyledAsterisk>**</StyledAsterisk> Caution! You cannot edit your application after
-          submitting.
-        </P>
-      )}
     </NavigationButtonsContainer>
   )
 }

--- a/src/containers/Application/Review.js
+++ b/src/containers/Application/Review.js
@@ -79,6 +79,7 @@ export default () => {
         secondButtonOnClick={() => handleSubmit()}
         autosaveTime={application.submission.lastUpdated.toDate().toString()}
         loading={loading}
+        showSubmitWarning
       />
     </>
   )


### PR DESCRIPTION
## Description
Closes #293

### Added warning text below `Submit` button
![image](https://user-images.githubusercontent.com/56183965/142133656-02a74b2d-c828-440d-bf6c-e87763d36d22.png)

### After submitting application, `Complete App` button is disabled
![image](https://user-images.githubusercontent.com/56183965/142134393-e63711c0-609d-43c5-8f88-20c5bbc164f7.png)

### After submitting application, user is redirected to dashboard when accessing certain endpoints
Before, users can go to `/application/part-123`, `/application/review`, `/application/confirmation` after submitting. This means they can potentially still edit their applications even if the `Complete App` button is disabled.

Added redirection when a user who already submitted their application attempts to access the endpoints mentioned above.

## Testing instructions

1.  Submit an application normally to make sure changes didn't break the usual workflow
2.  After submitting, try going to the mentioned endpoints and confirm that you were redirected to dashboard page
