### PR TITLE
HackerApplicationContext: Sync user object with template upon fetch

### DIFF
--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -9,8 +9,10 @@ import {
 } from './firebase'
 import firebase from 'firebase/app'
 import Spinner from '../components/Loading'
-import { ANALYTICS_EVENTS } from './Constants'
+import { ANALYTICS_EVENTS, HACKER_APPLICATION_TEMPLATE } from './Constants'
 import Closed from '../pages/Application/Closed'
+import { fillMissingProperties } from './utilities'
+
 const HackerApplicationContext = createContext()
 
 export function useHackerApplication() {
@@ -68,6 +70,7 @@ export function HackerApplicationProvider({ children }) {
     const retrieveApplication = async () => {
       if (!user) return
       const app = await getUserApplication(user.uid)
+      fillMissingProperties(app, HACKER_APPLICATION_TEMPLATE)
       setApplication(app)
       applicationRef.current = app
       setUpdated(false)

--- a/src/utility/HackerApplicationContext.js
+++ b/src/utility/HackerApplicationContext.js
@@ -41,6 +41,7 @@ export function HackerApplicationProvider({ children }) {
     const retrieveApplication = async () => {
       if (!user) return
       const app = await getUserApplication(user.uid)
+      fillMissingProperties(app, HACKER_APPLICATION_TEMPLATE)
       setApplication(app)
       setUpdated(false)
       analytics.logEvent(ANALYTICS_EVENTS.AccessApplication, { userId: user.uid })

--- a/src/utility/utilities.js
+++ b/src/utility/utilities.js
@@ -93,7 +93,7 @@ export function verifyObjectExists(obj, templateObj, key) {
     typeof obj === 'string' ||
     typeof templateObj === 'string' ||
     isNullOrUndefined(templateObj) ||
-    isNullOrUndefined(templateObj)
+    isNullOrUndefined(templateObj[key])
   )
     return
   if (obj[key] === undefined) {

--- a/src/utility/utilities.js
+++ b/src/utility/utilities.js
@@ -83,3 +83,29 @@ export const creatableDropdownValue = (arr, key, val) => {
     return createObj(val)
   }
 }
+
+const isNullOrUndefined = obj => obj === null || obj === undefined
+
+export function verifyObjectExists(obj, templateObj, key) {
+  if (
+    !key ||
+    key === '_id' ||
+    typeof obj === 'string' ||
+    typeof templateObj === 'string' ||
+    isNullOrUndefined(templateObj) ||
+    isNullOrUndefined(templateObj)
+  )
+    return
+  if (obj[key] === undefined) {
+    obj[key] = templateObj[key]
+  }
+  Object.keys(templateObj[key]).forEach(k => {
+    verifyObjectExists(obj[key], templateObj[key], k)
+  })
+}
+
+export const fillMissingProperties = (obj, templateObj) => {
+  Object.keys(templateObj).forEach(k => {
+    verifyObjectExists(obj, templateObj, k)
+  })
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->
See description of bug in #312 

Add function to recursively construct missing fields in hacker object synced with the `HACKER_APPLICATION_TEMPLATE`
- Also works for new field within nested obj

## Testing instructions
1. go to non-prod db
2. remove some fields from your own application object
3. reload page
4. page should not crash with error similar to #312 

Closes #312 