### PR TITLE
Set fallback active hackathon to hc

### DIFF
--- a/src/utility/HackathonProvider.jsx
+++ b/src/utility/HackathonProvider.jsx
@@ -11,7 +11,7 @@ export const useHackathon = function () {
 function getValidHackathon(hackathon) {
   // TODO: right now this logic fails when we're on a non-hackathon specific page like login
   // so for each hackathon we need to manually change fallback. This shouldn't be necessary ;-;
-  return VALID_HACKATHONS.includes(hackathon) ? hackathon : 'cmd-f'
+  return VALID_HACKATHONS.includes(hackathon) ? hackathon : 'hackcamp'
 }
 
 export default function HackathonProvider({ children }) {


### PR DESCRIPTION
## Description
<!--- Describe your changes! Include motivation, changes you made, screenshots/video if applicable -->
Set the fallback hackathon to `hackcamp` so the login page works for HC.


https://github.com/user-attachments/assets/4f9a8cb4-3e35-4734-a6c3-e9ebf040d4a6


## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
